### PR TITLE
feat: add app dashboard from ops with grafonnix

### DIFF
--- a/nix/cloud/dashboards/cardano-application-dashboard-v2.nix
+++ b/nix/cloud/dashboards/cardano-application-dashboard-v2.nix
@@ -1,0 +1,91 @@
+{ lib, ... }:
+(((lib.dashboard.new {
+  title = "Cardano: Application metrics v2";
+  timezone= "utc";
+  uid= "Oe0reiHef";
+  schemaVersion= 34;
+  graphTooltip = 0;
+})
+  .addAnnotation
+    (lib.kxPop (lib.annotation.datasource {
+      inherit (lib.annotation.default)
+        builtIn
+        datasource
+        hide
+        iconColor
+        name
+        type;
+    }) {
+      "$$hashKey" = "object:345";
+      target = {
+        limit = 100;
+        matchAny = false;
+        tags = [ ];
+        type = "dashboard";
+      };
+    })
+  )
+  .addPanel {
+    panel = ((((lib.statPanel.new {
+      title= "Current Node Version";
+      pluginVersion= "8.3.4";
+      datasource = {
+        type = "prometheus";
+        uid= "P1809F7CD0C75ACF3";
+      };
+      "colorMode"= "value";
+      "graphMode"= "none";
+      "justifyMode"= "auto";
+      "orientation"= "horizontal";
+      reducerFunction = "last";
+    })
+      .addMapping {
+        "options"= {
+          "match"= "null";
+          "result"= {
+            "text"= "N/A";
+          };
+        };
+        "type"= "special";
+      })
+      .addThreshold {
+        color = "green";
+        value = null;
+      })
+      .addTargets [
+        (lib.prometheus.target {
+          "expr"= "min(cardano_node_cli_version_major{alias!~\"snapshots|explorer-.*|.*Test.*\"})";
+          "instant"= true;
+          "interval"= "";
+          "legendFormat"= "Node Major Version:";
+        })
+        (lib.prometheus.target {
+          "expr"= "min(cardano_node_cli_version_major{alias!~\"snapshots|explorer-.*|.*Test.*\"})";
+          "instant"= true;
+          "interval"= "";
+          "legendFormat"= "Node Major Version:";
+          "refId"= "A";
+        })
+        (lib.prometheus.target {
+          "expr"= "min(cardano_node_cli_version_minor{alias!~\"snapshots|explorer-.*|.*Test.*\"})";
+          "instant"= true;
+          "interval"= "";
+          "legendFormat"= "Node Minor Version:";
+          "refId"= "B";
+        })
+        (lib.prometheus.target {
+          "expr"= "min(cardano_node_cli_version_patch{alias!~\"snapshots|explorer-.*|.*Test.*\"})";
+          "instant"= true;
+          "interval"= "";
+          "legendFormat"= "Node Patch Version:";
+          "refId"= "C";
+        })
+      ])
+      ;
+    gridPos = {
+      "h"= 6;
+      "w"= 8;
+      "x"= 0;
+      "y"= 0;
+    };
+  })


### PR DESCRIPTION
Just as an example, I re-implemented the app dashboard with only one panel from [cardano-ops](https://github.com/input-output-hk/cardano-ops/blob/a67896c6a5ecac817581347e864e6a0c376b1b8d/modules/grafana/cardano/cardano-application-dashboard-v2.json)

Practically though, I think the json dashboards could just be copied over and the grafonnix generated nix code can be merged in, so that the dashboards can gradually be ported over to grafonnix.

cc @johnalotoski @jbgi @blaggacao 