### PR TITLE
Switch nixpkgs used by haskell.nix to use glibc 2.34

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -6133,8 +6133,7 @@
         "nix-inclusive": "nix-inclusive",
         "nixpkgs": "nixpkgs_59",
         "nixpkgs-haskell": [
-          "haskell-nix",
-          "nixpkgs-unstable"
+          "nixpkgs"
         ],
         "std": "std_2"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@
     # --------------------------------------------------------------
     # --- Auxiliaries ----------------------------------------------
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
-    nixpkgs-haskell.follows = "haskell-nix/nixpkgs-unstable";
+    nixpkgs-haskell.follows = "nixpkgs";
     capsules.url = "github:input-output-hk/devshell-capsules";
     # --------------------------------------------------------------
     # --- Bride Heads ----------------------------------------------


### PR DESCRIPTION
so that the devshell is compatible with direnv from nixos-22.05.
(nixpkgs-unstable in haskell.nix is still on 2.33)