### PR TITLE
Update mainnet snapshot reference

### DIFF
--- a/nix/cardano/constants.nix
+++ b/nix/cardano/constants.nix
@@ -23,7 +23,7 @@
     # https://update-cardano-mainnet.iohk.io/cardano-db-sync/index.html#13/
     mainnet = {
       base_url = "https://update-cardano-mainnet.iohk.io/cardano-db-sync/13";
-      file_name = "db-sync-snapshot-schema-13-block-7477999-x86_64.tgz ";
+      file_name = "db-sync-snapshot-schema-13-block-7498999-x86_64.tgz";
     };
   };
 }


### PR DESCRIPTION
Update the mainnet db-sync snapshot reference to the latest one from the [db sync mainnet link](https://update-cardano-mainnet.iohk.io/cardano-db-sync/index.html#13/ )