### PR TITLE
ogmios: Fix Nomad job and entrypoint

### DIFF
--- a/nix/cardano/entrypoints.nix
+++ b/nix/cardano/entrypoints.nix
@@ -558,7 +558,7 @@ in {
 
       # Build args array
       args+=("--host" "0.0.0.0")
-      args+=("--port" "8070")
+      args+=("--port" "1337")
       args+=("--node-socket" "$SOCKET_PATH")
       args+=("--node-config" "$NODE_CONFIG")
 

--- a/nix/cardano/nomadJob/ogmios.nix
+++ b/nix/cardano/nomadJob/ogmios.nix
@@ -97,7 +97,6 @@ in
                 (import ./srv-ogmios.nix {inherit namespace healthChecks;})
               ];
               network = {
-                dns = {servers = update [0] ["172.17.0.1"];};
                 mode = "bridge";
                 port.ogmios = {to = 1337;};
               };


### PR DESCRIPTION
* entrypoint used non-default port 8070 while 1337 is used everywhere
* Nomad job used data-merge's `update [0] [".."]` on a list that resulted in dict instead of list:

  ```
  nix-repl> :p (x86_64-linux.cardano.nomadJob.cardano-node args).job.cardano.group.cardano.network.dns
  { servers = [ "172.17.0.1" ]; }
  
  nix-repl> :p (x86_64-linux.cardano.nomadJob.ogmios args).job.ogmios.group.ogmios.network.dns
  { servers = [ { "0" = "172.17.0.1"; } ]; }
  ```
  
  remove dns.servers from ogmios job since it's already defined in node