### PR TITLE
ogmios: Switch to HTTP healthcheck

### DIFF
--- a/nix/cardano/nomadJob/srv-ogmios.nix
+++ b/nix/cardano/nomadJob/srv-ogmios.nix
@@ -6,16 +6,10 @@
   check = [
     {
       address_mode = "host";
-      args = ["health-check"];
-      # FIXME: switch back to fully qualified invocation
-      # after: https://github.com/nlewo/nix2container/issues/15
-      # command = "${healthChecks.cardano-wallet-network-sync}/bin/healthcheck";
-      command = "/bin/ogmios";
+      type = "http";
+      path = "/health";
       interval = "30s";
-      # on_update = "ignore_warnings";
-      # check_restart.ignore_warnings = true;
       timeout = "10s";
-      type = "script";
     }
   ];
   task = "ogmios";


### PR DESCRIPTION
Script is not accessible in `/bin/ogmios` anymore, and it does the same thing, only from within the container.