### PR TITLE
dashboards: make reusable from other clusters

### DIFF
--- a/nix/cloud/dashboards/application-metrics.json
+++ b/nix/cloud/dashboards/application-metrics.json
@@ -30,7 +30,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -110,7 +110,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "cardano_node_metrics_blockNum_int{namespace=\"$namespace\"}",
@@ -127,7 +127,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -207,7 +207,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "cardano_node_metrics_slotNum_int{namespace=\"$namespace\"}",
@@ -223,7 +223,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -304,7 +304,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "quantile(0.5,cardano_node_metrics_density_real{namespace=\"$namespace\"}) / 0.05",
@@ -322,7 +322,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -402,7 +402,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "cardano_node_metrics_epoch_int{namespace=\"$namespace\"}",
@@ -417,7 +417,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "description": "Calculated at a 1 hr averaging window",
       "fieldConfig": {
@@ -499,7 +499,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "rate(cardano_node_metrics_Forge_node_is_leader_int{namespace=\"$namespace\"}[1h])/rate(cardano_node_metrics_slotNum_int{namespace=\"$namespace\"}[1h]) / 0.05",
@@ -510,7 +510,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "sum(rate(cardano_node_metrics_Forge_node_is_leader_int{namespace=\"$namespace\"}[1h])/rate(cardano_node_metrics_slotNum_int{namespace=\"$namespace\"}[1h])) / 0.05",
@@ -525,7 +525,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -607,7 +607,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "cardano_node_metrics_Forge_forged_int{namespace=\"$namespace\"} - cardano_node_metrics_Forge_adopted_int{namespace=\"$namespace\"}",
@@ -622,7 +622,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -702,7 +702,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "cardano_node_metrics_slotInEpoch_int{namespace=\"$namespace\"}",
@@ -717,7 +717,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -796,7 +796,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "rate(cardano_node_metrics_slotsMissedNum_int{namespace=\"$namespace\"}[1h]) * 3600",
@@ -812,7 +812,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "description": "",
       "fieldConfig": {
@@ -891,7 +891,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "avg(avg_over_time(cardano_node_metrics_txsInMempool_int{namespace=\"$namespace\"}[30m]))",
@@ -907,7 +907,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -987,7 +987,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "rate(cardano_node_metrics_blockNum_int{namespace=\"$namespace\"}[150s])*60",
@@ -1003,7 +1003,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -1083,7 +1083,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": false,
           "expr": "quantile(0.5, cardano_node_metrics_blockfetchclient_blocksize{namespace=\"$namespace\"} / 66636)",
@@ -1097,7 +1097,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "avg(avg_over_time(cardano_node_metrics_blockfetchclient_blocksize{namespace=\"$namespace\"}[15m]) / 66636)",
@@ -1110,7 +1110,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "avg(avg_over_time(cardano_node_metrics_blockfetchclient_blocksize{namespace=\"$namespace\"}[4h]) / 66636)",
@@ -1123,7 +1123,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "avg(avg_over_time(cardano_node_metrics_blockfetchclient_blocksize{namespace=\"$namespace\"}[24h]) / 66636)",
@@ -1136,7 +1136,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "avg(avg_over_time(cardano_node_metrics_blockfetchclient_blocksize{namespace=\"$namespace\"}[7d]) / 66636)",
@@ -1153,7 +1153,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "description": "Remaining faucet funds in ADA",
       "fieldConfig": {
@@ -1234,7 +1234,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "cardano_faucet_metrics_value_available{namespace=\"$namespace\"} / 1e6",
@@ -1249,7 +1249,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -1314,7 +1314,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "quantile(0.5,cardano_node_metrics_currentKESPeriod_int{namespace=\"$namespace\"})",
@@ -1329,7 +1329,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -1410,7 +1410,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "irate((rts_gc_cpu_ms{namespace=\"$namespace\"} + rts_gc_mutator_cpu_ms{namespace=\"$namespace\"} + rts_gc_init_cpu_ms{namespace=\"$namespace\"})[1m]) / 1000",
@@ -1425,7 +1425,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -1505,7 +1505,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "rts_gc_current_bytes_used{namespace=\"$namespace\"}",
@@ -1520,7 +1520,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "description": "KES periods remaining",
       "fieldConfig": {
@@ -1601,7 +1601,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "cardano_node_metrics_remainingKESPeriods_int{namespace=\"$namespace\"}",
@@ -1616,7 +1616,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "description": "Counts only memory that is physically free",
       "fieldConfig": {
@@ -1696,7 +1696,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "rts_gc_peak_megabytes_allocated{namespace=\"$namespace\"}",
@@ -1711,7 +1711,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -1790,7 +1790,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "rts_gc_max_bytes_used{namespace=\"$namespace\"}",
@@ -1817,7 +1817,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "KjvoGGUnz"
+          "uid": "VictoriaMetrics"
         },
         "definition": "label_values(namespace)",
         "hide": 0,

--- a/nix/cloud/dashboards/p2p.json
+++ b/nix/cloud/dashboards/p2p.json
@@ -29,7 +29,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -107,7 +107,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "cardano_node_metrics_connectionManager_duplexConns{namespace=\"$namespace\"}",
@@ -123,7 +123,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -201,7 +201,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "cardano_node_metrics_peerSelection_hot{namespace=\"$namespace\"}",
@@ -217,7 +217,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -295,7 +295,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "cardano_node_metrics_inboundGovernor_hot{namespace=\"$namespace\"}",
@@ -311,7 +311,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -389,7 +389,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "cardano_node_metrics_connectionManager_unidirectionalConns{namespace=\"$namespace\"}",
@@ -405,7 +405,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -483,7 +483,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "cardano_node_metrics_peerSelection_warm{namespace=\"$namespace\"}",
@@ -499,7 +499,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -577,7 +577,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "cardano_node_metrics_inboundGovernor_warm{namespace=\"$namespace\"}",
@@ -593,7 +593,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -671,7 +671,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "cardano_node_metrics_connectionManager_incomingConns{namespace=\"$namespace\"}",
@@ -687,7 +687,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -765,7 +765,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "cardano_node_metrics_peerSelection_cold{namespace=\"$namespace\"}",
@@ -781,7 +781,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -859,7 +859,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "rate(cardano_node_metrics_served_block_latest_count_int{namespace=\"$namespace\"}[1h])/rate(cardano_node_metrics_blockNum_int{namespace=\"$namespace\"}[1h])",
@@ -875,7 +875,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -953,7 +953,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "cardano_node_metrics_connectionManager_outgoingConns{namespace=\"$namespace\"}",
@@ -969,7 +969,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -1047,7 +1047,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "cardano_node_metrics_blockfetchclient_blockdelay_cdfOne{namespace=\"$namespace\"}",
@@ -1063,7 +1063,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -1141,7 +1141,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "cardano_node_metrics_blockadoption_cdfOne_real{namespace=\"$namespace\"}",
@@ -1157,7 +1157,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -1235,7 +1235,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "cardano_node_metrics_connectionManager_prunableConns{namespace=\"$namespace\"}",
@@ -1251,7 +1251,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -1329,7 +1329,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "cardano_node_metrics_blockfetchclient_blockdelay_cdfThree{namespace=\"$namespace\"}",
@@ -1345,7 +1345,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -1423,7 +1423,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "cardano_node_metrics_blockadoption_cdfThree_real{namespace=\"$namespace\"}",
@@ -1439,7 +1439,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -1517,7 +1517,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "rate(cardano_node_metrics_blockfetchclient_lateblocks{namespace=\"$namespace\"}[1h])/rate(cardano_node_metrics_blockNum_int{namespace=\"$namespace\"}[1h])",
@@ -1533,7 +1533,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -1611,7 +1611,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "cardano_node_metrics_blockfetchclient_blockdelay_cdfFive{namespace=\"$namespace\"}",
@@ -1627,7 +1627,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -1705,7 +1705,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "cardano_node_metrics_blockadoption_cdfFive_real{namespace=\"$namespace\"}",
@@ -1721,7 +1721,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -1801,7 +1801,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "avg(quantile_over_time(0.5,cardano_node_metrics_blockfetchclient_blockdelay_s{namespace=\"$namespace\"}[15m]))",
@@ -1813,7 +1813,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "avg(quantile_over_time(0.95,cardano_node_metrics_blockfetchclient_blockdelay_s{namespace=\"$namespace\"}[15m]))",
@@ -1830,7 +1830,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "description": "",
       "fieldConfig": {
@@ -1909,7 +1909,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "cardano_node_metrics_blockadoption_delay_real{namespace=\"$namespace\"}",
@@ -1925,7 +1925,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "description": "",
       "fieldConfig": {
@@ -2004,7 +2004,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "avg(quantile_over_time(0.5, cardano_node_metrics_blockadoption_forgeDelay_real{namespace=\"$namespace\"}[15m]))",
@@ -2016,7 +2016,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "avg(quantile_over_time(0.95, cardano_node_metrics_blockadoption_forgeDelay_real{namespace=\"$namespace\"}[1h]))",
@@ -2028,7 +2028,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "avg(quantile_over_time(0.95, cardano_node_metrics_blockadoption_forgeDelay_real{namespace=\"$namespace\"}[6h:30s]))",
@@ -2056,7 +2056,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "KjvoGGUnz"
+          "uid": "VictoriaMetrics"
         },
         "definition": "label_values(namespace)",
         "hide": 0,

--- a/nix/cloud/dashboards/performance.json
+++ b/nix/cloud/dashboards/performance.json
@@ -29,7 +29,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "description": "",
       "fieldConfig": {
@@ -111,7 +111,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "$function(rts_gc_current_bytes_used{nomad_alloc_name=~\"$name_filter\"}) by (namespace)",
@@ -126,7 +126,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "description": "",
       "fieldConfig": {
@@ -208,7 +208,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "$function(avg_over_time(cardano_node_metrics_blockfetchclient_blockdelay_s{nomad_alloc_name=~\"$name_filter\"}[5m])) by (namespace)",
@@ -223,7 +223,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "description": "",
       "fieldConfig": {
@@ -305,7 +305,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "$function((irate((rts_gc_cpu_ms{nomad_alloc_name=~\"$name_filter\"} + rts_gc_mutator_cpu_ms{nomad_alloc_name=~\"$name_filter\"} + rts_gc_init_cpu_ms{nomad_alloc_name=~\"$name_filter\"})[1m]))/ 1000) by (namespace)",
@@ -324,7 +324,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "description": "",
       "fill": 1,
@@ -369,7 +369,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "$function(cardano_node_metrics_connectionManager_unidirectionalConns{nomad_alloc_name=~\"$name_filter\"} + cardano_node_metrics_connectionManager_duplexConns{nomad_alloc_name=~\"$name_filter\"}) by (namespace)",
@@ -413,7 +413,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "KjvoGGUnz"
+        "uid": "VictoriaMetrics"
       },
       "fieldConfig": {
         "defaults": {
@@ -494,7 +494,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "KjvoGGUnz"
+            "uid": "VictoriaMetrics"
           },
           "exemplar": true,
           "expr": "$function(rate(cardano_node_metrics_served_block_latest_count_int{nomad_alloc_name=~\"$name_filter\"}[1h])/rate(cardano_node_metrics_blockNum_int{nomad_alloc_name=~\"$name_filter\"}[1h])) by (namespace)",
@@ -543,7 +543,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "KjvoGGUnz"
+          "uid": "VictoriaMetrics"
         },
         "definition": "label_values(nomad_alloc_name)",
         "description": "Nomad alloc name",


### PR DESCRIPTION
The datasource needs to be set to `VictoriaMetrics` instead of a hardcoded, cluster specific UID to make these dashboards reusable.

Tested and working in Mamba World.