### PR TITLE
implement recaptcha

### DIFF
--- a/nix/cardano/entrypoints.nix
+++ b/nix/cardano/entrypoints.nix
@@ -586,8 +586,11 @@ in {
 
   cardano-faucet = writeShellApplication {
     debugInputs = [packages.cardano-cli];
+    runtimeInputs = [ nixpkgs.cacert ];
     name = "entrypoint";
     text = ''
+      # shellcheck source=/dev/null
+      source ${nixpkgs.cacert}/nix-support/setup-hook
       exec ${packages.cardano-new-faucet}/bin/cardano-new-faucet
     '';
   };

--- a/nix/cardano/entrypoints.nix
+++ b/nix/cardano/entrypoints.nix
@@ -586,7 +586,7 @@ in {
 
   cardano-faucet = writeShellApplication {
     debugInputs = [packages.cardano-cli];
-    runtimeInputs = [ nixpkgs.cacert ];
+    runtimeInputs = [nixpkgs.cacert];
     name = "entrypoint";
     text = ''
       # shellcheck source=/dev/null

--- a/nix/cardano/nomadCharts/cardano-faucet.nix
+++ b/nix/cardano/nomadCharts/cardano-faucet.nix
@@ -101,7 +101,7 @@ in
                   tags = [
                     "ingress"
                     "traefik.enable=true"
-                    "traefik.http.routers.cardano-faucet-${namespace}.rule=Host(`faucet.${domain}`) && PathPrefix(`/{send-money,delegate}`)"
+                    "traefik.http.routers.cardano-faucet-${namespace}.rule=Host(`faucet.${domain}`) && PathPrefix(`/{send-money,delegate,get-site-key,basic-faucet}`)"
                     "traefik.http.routers.cardano-faucet-${namespace}.entrypoints=https"
                     "traefik.http.routers.cardano-faucet-${namespace}.tls.certresolver=acme"
                   ];

--- a/nix/cloud/kv/vault/faucet/preprod.enc.json
+++ b/nix/cloud/kv/vault/faucet/preprod.enc.json
@@ -3,7 +3,7 @@
 	"api_keys": [
 		{
 			"api_key": "ENC[AES256_GCM,data:wImtEgpP7kPELyHsxzIXK8Lyx1E2G2iD/0JO5ZCurRU=,iv:6pE98YzckDzAbidYEztlg69/PimkbVKlAw5kwWvEE8c=,tag:t5ayWEpdVSXcJgF8HCfxiA==,type:str]",
-			"lovelace": "ENC[AES256_GCM,data:NfioeWQ3IVt7yJQ=,iv:N6L2yZGpIFdyi38scIsWK1StROmeo37FE24p4UNkHrg=,tag:ZJjYiKAALOs33bTvek5rtw==,type:float]",
+			"lovelace": "ENC[AES256_GCM,data:dgpetbIvWd4eXMw=,iv:XhJeuR2Sp6+0QfMiHi6U0DefFIeM9ExdN/B08cut0uM=,tag:aUG0yF40UgHz6a2U971tVw==,type:float]",
 			"rate_limit": "ENC[AES256_GCM,data:a0c=,iv:d0qQOqOKE0EwSGjvsKaVQh5ZNygShJgTpDdGJRg79X8=,tag:8qSoeCqJIY9fWVKWPRcC9g==,type:float]",
 			"tokens": []
 		},
@@ -51,6 +51,11 @@
 	"network": {
 		"Testnet": "ENC[AES256_GCM,data:5A==,iv:iVNadLMoXsHtSjRQTzj/rrZhKULqr6jsc4i+Tn6QM8w=,tag:1NmIz9k0IVJbJjAsh0VFdA==,type:float]"
 	},
+	"recaptcha_site_key": "ENC[AES256_GCM,data:BuaOpZBOmXf0wJ9WMKU/vSsi3AYOd7UdZmOWmBluDL0gGYVrc2Jf,iv:UlhGBMwoacdhjtqHm4ls2nd6YpsF7ZSZUv8egCrCbhE=,tag:KofGX0tFGO9fgqk9fgIimg==,type:str]",
+	"recaptcha_secret_key": "ENC[AES256_GCM,data:MTySpWt1Nlt/n7xujbUfQJMXoE/DWi96gVLtPPvA3MZzm16M8OM/5g==,iv:eCPekM/LDqRoLQb7PYGUX3SR2cw0Ct/mFprrQr5jjqk=,tag:oVnZbL96F62nOPBqpJgw6Q==,type:str]",
+	"allowed_cors_origins": [
+		"ENC[AES256_GCM,data:hgz4pcU8LSIb2hOumlQTvpD0jo3FIBKt,iv:vykSkQF+m2bWuR4K4prclhJE+4pZ7e5h4LuwLX4yuw0=,tag:Dnh8VBFAxKyEniv4SlxBxA==,type:str]"
+	],
 	"sops": {
 		"kms": null,
 		"gcp_kms": null,
@@ -65,8 +70,8 @@
 			}
 		],
 		"age": null,
-		"lastmodified": "2022-08-08T13:08:02Z",
-		"mac": "ENC[AES256_GCM,data:TzFxBWsR7QYOWQjQOFUm+G4i12EZdKZ9zFwkT4Im1NjvzOpVGuPXyzZBfJZ4nNZqeoVIjOeHq7d6nDN++g9ZoqCuC+pDJb+1lJ3LNRwz9mh/j05TQbIDcTIWuD4hjDpOxQ7T1sFiKbxx7arhnITemn5XOdwsby/UGQA7U9wYbAU=,iv:xacosgyD4Fhm7mqoICr7uXh3i+r0I0qi0+BgQv5ogws=,tag:B+jf3Nf19kFAnABOlIPF0A==,type:str]",
+		"lastmodified": "2022-08-15T20:21:30Z",
+		"mac": "ENC[AES256_GCM,data:NTA0r9Zh+ch5gY05YRu6h6UM21EGpkrY5NCHUttJ/KHpaZtwV5SHuDmM7SYGtCzQ0TvPXveoSlJ3Wpx20UPXnNBAU8wf6cJ1CxsK1cMn2e/CGMtRmBHXkTKfhP5xdkow6ty84hR0tb2THAna2AznubsPIARdJNZpj0ffa696pLo=,iv:P34yilOirVbGlMrjEJP6lr2u3zVfkbyOVRAD2NxR0NY=,tag:guzooffrLS7PmZO9lrzj6Q==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.7.2"

--- a/nix/cloud/kv/vault/faucet/preprod.enc.json
+++ b/nix/cloud/kv/vault/faucet/preprod.enc.json
@@ -51,7 +51,7 @@
 	"network": {
 		"Testnet": "ENC[AES256_GCM,data:5A==,iv:iVNadLMoXsHtSjRQTzj/rrZhKULqr6jsc4i+Tn6QM8w=,tag:1NmIz9k0IVJbJjAsh0VFdA==,type:float]"
 	},
-	"recaptcha_site_key": "ENC[AES256_GCM,data:BuaOpZBOmXf0wJ9WMKU/vSsi3AYOd7UdZmOWmBluDL0gGYVrc2Jf,iv:UlhGBMwoacdhjtqHm4ls2nd6YpsF7ZSZUv8egCrCbhE=,tag:KofGX0tFGO9fgqk9fgIimg==,type:str]",
+	"recaptcha_site_key": "ENC[AES256_GCM,data:Z0LTtzKgzp4kGt9EnrxhOQ4rmBgtQ1LKiG/xl80ZZ67cReYf+YwWxw==,iv:f7qUv9Vl/e1oPJdoobSxiupCMmC2dEGumorX+N+t45U=,tag:ctmiwtfKWJsksrmiTbh4xg==,type:str]",
 	"recaptcha_secret_key": "ENC[AES256_GCM,data:MTySpWt1Nlt/n7xujbUfQJMXoE/DWi96gVLtPPvA3MZzm16M8OM/5g==,iv:eCPekM/LDqRoLQb7PYGUX3SR2cw0Ct/mFprrQr5jjqk=,tag:oVnZbL96F62nOPBqpJgw6Q==,type:str]",
 	"allowed_cors_origins": [
 		"ENC[AES256_GCM,data:hgz4pcU8LSIb2hOumlQTvpD0jo3FIBKt,iv:vykSkQF+m2bWuR4K4prclhJE+4pZ7e5h4LuwLX4yuw0=,tag:Dnh8VBFAxKyEniv4SlxBxA==,type:str]"
@@ -70,8 +70,8 @@
 			}
 		],
 		"age": null,
-		"lastmodified": "2022-08-15T20:21:30Z",
-		"mac": "ENC[AES256_GCM,data:NTA0r9Zh+ch5gY05YRu6h6UM21EGpkrY5NCHUttJ/KHpaZtwV5SHuDmM7SYGtCzQ0TvPXveoSlJ3Wpx20UPXnNBAU8wf6cJ1CxsK1cMn2e/CGMtRmBHXkTKfhP5xdkow6ty84hR0tb2THAna2AznubsPIARdJNZpj0ffa696pLo=,iv:P34yilOirVbGlMrjEJP6lr2u3zVfkbyOVRAD2NxR0NY=,tag:guzooffrLS7PmZO9lrzj6Q==,type:str]",
+		"lastmodified": "2022-08-15T21:24:05Z",
+		"mac": "ENC[AES256_GCM,data:iP6dPTjQwbBXNJLO/ydm+YhspX5PmPtrcrcNtwR/5BxROjNg2BD7UUhJ8pX9+cp2SvaiEF8GYjWlAA+zMY2KJO3skY1vEo4A3asbnG2XmYEUbMm2zTEgMe56o7ORzeRtDAzXJ9QeLSw/uhlYsNpG+pmWMAZIHxFvR3yC9PmKvZg=,iv:igR6ZfUqc+bR+mFYdVgM4FQ+b9dfYEYNZLMl7nP3YRs=,tag:uE6Uvzj8taIZL1Lm0CxRMw==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.7.2"

--- a/nix/cloud/kv/vault/faucet/preview.enc.json
+++ b/nix/cloud/kv/vault/faucet/preview.enc.json
@@ -3,7 +3,7 @@
 	"api_keys": [
 		{
 			"api_key": "ENC[AES256_GCM,data:Y7K7gb6EaPbfvROUshWn2x8yY/qFZ8Ern78z3Khi3q8=,iv:G3CyistzO1QB4HZlfoO71I0h1Izbj+T7AtITxMG4C0A=,tag:IBauLu3CNly6D6Cvb85NTQ==,type:str]",
-			"lovelace": "ENC[AES256_GCM,data:g/U11Q2/QS1dMvw=,iv:a8O+5yPvAxy3a7sw11OIbCmsrDH3Wm8+wsJkeEgUQFs=,tag:uqT7w3DwXC7J8aAq7P/rYw==,type:float]",
+			"lovelace": "ENC[AES256_GCM,data:OJnERY+9ry4Iq8w=,iv:F2AzvOPU+PZgKfB8SN5BMv5VbotwKmeTVeCjf8VJQqI=,tag:l08VMwFQ+G7Legc47hiJlg==,type:float]",
 			"rate_limit": "ENC[AES256_GCM,data:wtM=,iv:K5JUlpnA8SM/irHnmGB1m15CfcdfMXOpvwIoeBIfPm8=,tag:ygjWc/RewcA/6b8wFTWIXA==,type:float]",
 			"tokens": []
 		},
@@ -51,6 +51,11 @@
 	"network": {
 		"Testnet": "ENC[AES256_GCM,data:/g==,iv:Ohnz5vI7zHqB9Ekm+30eqQFqzVKewwUTEtoHlQFnsOc=,tag:0eOlN4ou/hTvgqeV0NuenA==,type:float]"
 	},
+	"recaptcha_site_key": "ENC[AES256_GCM,data:ldXxu3mmi1El6CSYP/oEPe6bC/KMY5/VDslrrF3BNQ04l+3tW1cDDg==,iv:eUF7zgB1dh32LTuZX2uzQU41IbhT9tpTeROraYv/ACc=,tag:uaxD/3qORMVHm+Z/lu3b5Q==,type:str]",
+	"recaptcha_secret_key": "ENC[AES256_GCM,data:1wETN5Xw2MNNDLskN1S/GXoaNlsxBGtEYNlLjZ6VwecycBDqkMtK5g==,iv:cplpe4xkEtVi3dQXcO/CF3aFOXejLz3OtpCce6Kjlic=,tag:V6/98WYW55CBi7huRNe4hA==,type:str]",
+	"allowed_cors_origins": [
+		"ENC[AES256_GCM,data:l0nmkZYTcdDS6rXUJ3jxKuXzg+UoYTsW,iv:HTyp5U96QGpj0IpzVfgdyY7NaKnRUNR8+LowzNRtgeg=,tag:PI7hIAiqHREU4z9RH7RyOQ==,type:str]"
+	],
 	"sops": {
 		"kms": null,
 		"gcp_kms": null,
@@ -65,8 +70,8 @@
 			}
 		],
 		"age": null,
-		"lastmodified": "2022-08-12T03:21:47Z",
-		"mac": "ENC[AES256_GCM,data:ZysskMVGg+QrExaKmKF+fuNawuOGIiRVbSnV2yK1OBiiObo2A/QGZhF1U7S6tDb+/g1F+W/zfI6ug786H3f8pzSAhp6KeIpT9Y1PrlwDwDJzXpZH+4/SRE/l1DVVuZN/aYbXwE9+eW2ueL4Hc6MRRz0dtRKHCv9CLEw7eeOQEUs=,iv:R2EvHE99ha/+hZUersS6TPKZeuU/4JOWnq45BnlICgA=,tag:aI0EkSYB9VjKF7vLo2NJ6g==,type:str]",
+		"lastmodified": "2022-08-15T20:19:37Z",
+		"mac": "ENC[AES256_GCM,data:BkgvwEP/thWOQLxF0Ry/fEImM535hTenKaH3YVOZC5fFwgZmzu5bFRV5JpnEpZF39EKOQ4twMjfVBDfSJbkfdP/GvNf04AHb3cYC+bxXAVgHcCoio9EWtAk9Ft91G5aaNxBxhhWCR2F/lg5x0mkRJzqAl9pdLRQZ35m/if88sdA=,iv:tOdKtM41ElkJP8KQCEp1LSGpd6jCwPnMiWzHuulxu3Q=,tag:u0uwavpQGuUNuLJtcvb+Mg==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.7.2"

--- a/nix/cloud/kv/vault/faucet/vasil-dev.enc.json
+++ b/nix/cloud/kv/vault/faucet/vasil-dev.enc.json
@@ -51,6 +51,11 @@
 	"network": {
 		"Testnet": "ENC[AES256_GCM,data:6Q==,iv:Ce0D+b+1k5Q6ntHXqwGrYJ9DO6sHbzth3qWrIFtb2Is=,tag:HDKnVjFm1Oqgd37NM8mTZA==,type:float]"
 	},
+	"recaptcha_site_key": "ENC[AES256_GCM,data:m7s9ddRfzpgRCEvHQZ6424CLuB6x3Y6f8kRVoIltjK62GUQsurrKcg==,iv:tQcn1WqUJHRtW7ruRKCijaWZCS2CV9uCsdBr+LiAz8Q=,tag:IyM2X/w7ia1NgsIu2mqgYw==,type:str]",
+	"recaptcha_secret_key": "ENC[AES256_GCM,data:XgWUsw6nK0nUBAX5SZNjkjCTHcrQ3gML/f6zyl5ra748oLnzKzc7hw==,iv:UTTGnWqlL3D+JvjO39ZVQjufSvizzEnPKsRFWdJWa2A=,tag:znxaACWQ8HOqJfLdG2htAQ==,type:str]",
+	"allowed_cors_origins": [
+		"ENC[AES256_GCM,data:PUW/n0GQVAPO8vvrsd2VXkCYCWzAvGqc,iv:j+/XmQriqvN8H7TFncX4ZAcrbHpQQnrhZNv3ng78ST4=,tag:/kQ7DatF0kZrCZXDrl6pNA==,type:str]"
+	],
 	"sops": {
 		"kms": null,
 		"gcp_kms": null,
@@ -65,8 +70,8 @@
 			}
 		],
 		"age": null,
-		"lastmodified": "2022-08-07T03:14:49Z",
-		"mac": "ENC[AES256_GCM,data:NP/GbwcAqoi4JqtRHfqtmvqdj6kIdd1iKsQY6zttdXtRCoHTemYBYjDG5WH4H827UPIUC2gItGKxT9TaWQA8R/RgsAkPSz4MKNxgzsDVHHgsLeH5w8SCpgMcCfVC1GUqrfXJxLr6e74lzEoIWnilj1IYmXMMMr1dogFurMR2kUo=,iv:mxNYqr3cboTypQi0rQbyUSVgePA93Cpk1BjMiCuQUi0=,tag:j5ZXm5He90a9UYBD2uzLJg==,type:str]",
+		"lastmodified": "2022-08-15T20:18:17Z",
+		"mac": "ENC[AES256_GCM,data:H02y0DuzmgCjFXrcflI7meVNWimzjGNy2IALdxWN0zdO7OljXMmMjROzIqQMKiXDLWfa1LLdyo5az/9ZtsynY+OnBMtEZh1ldtry7yMNS+/YeMMsyW/txJiXPvLNFVdzbhEAJKGVwYrf9DVDXxfZYNOWtqRboyaUJmg2Rh4uMtg=,iv:CB67hNFUTMNZwBSKOYoExMXXvHkz7kYVcKPYSkrrmf8=,tag:opZ7t4S+Hjtt18w56NAJpA==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.7.2"

--- a/src/cardano-faucet/cardano-faucet.cabal
+++ b/src/cardano-faucet/cardano-faucet.cabal
@@ -10,6 +10,8 @@ license-files:          LICENSE
                         NOTICE
 build-type:             Simple
 extra-source-files:     README.md
+data-dir:             data
+data-files:           index.html
 
 Flag unexpected_thunks
   Description:   Turn on unexpected thunks checks
@@ -56,6 +58,7 @@ library
                         Cardano.Faucet.Types
                         Cardano.Faucet.Utils
                         Cardano.Faucet.Web
+                        Paths_cardano_faucet
 
   build-depends:        aeson             >= 1.5.6.0
                       , MissingH
@@ -69,6 +72,7 @@ library
                       , formatting
                       , http-api-data
                       , http-client-tls
+                      , http-media
                       , iproute
                       , network
                       , ouroboros-consensus
@@ -89,3 +93,4 @@ executable cardano-new-faucet
   import:               base, project-config
   main-is:              cardano-new-faucet.hs
   build-depends:        cardano-faucet
+  ghc-options:          -threaded

--- a/src/cardano-faucet/data/index.html
+++ b/src/cardano-faucet/data/index.html
@@ -1,0 +1,19 @@
+<html>
+  <head>
+    <script src="/get-site-key"></script>
+    <script>
+      function onLoadCallback() {
+        grecaptcha.render("widget", { sitekey: site_key });
+      }
+    </script>
+    <script src="https://www.google.com/recaptcha/api.js?onload=onLoadCallback&render=explicit" async defer></script>
+  </head>
+  <body>
+    <form action="/send-money" method="get">
+      <div id=widget></div>
+      address(required): <input type=text name="address" size=50 /><br/>
+      api key(optional): <input type=text name="api_key" /><br/>
+      <input type=submit>
+    </form>
+  </body>
+</html>

--- a/src/cardano-faucet/src/Cardano/Faucet.hs
+++ b/src/cardano-faucet/src/Cardano/Faucet.hs
@@ -48,13 +48,15 @@ import System.IO (hSetBuffering, BufferMode(LineBuffering))
 import Cardano.Address.Derivation (Depth(AccountK), XPrv)
 import Formatting ((%), format)
 import Formatting.ShortFormatters hiding (x, b, f, l)
+import Paths_cardano_faucet (getDataFileName)
 
 app :: IsShelleyBasedEra era =>
   CardanoEra era
   -> ShelleyBasedEra era
   -> FaucetState era
+  -> Text
   -> Application
-app era sbe faucetState = serve userAPI $ server era sbe faucetState
+app era sbe faucetState indexHtml = serve userAPI $ server era sbe faucetState indexHtml
 
 startApiServer :: IsShelleyBasedEra era =>
   CardanoEra era
@@ -65,7 +67,10 @@ startApiServer :: IsShelleyBasedEra era =>
 startApiServer era sbe faucetState port = do
   let
     settings = setTimeout 600 $ setPort port $ defaultSettings
-  runSettings settings (app era sbe faucetState)
+  index_path <- getDataFileName "index.html"
+  print index_path
+  index_html <- readFile index_path
+  runSettings settings (app era sbe faucetState index_html)
 
 findAllSizes :: FaucetConfigFile -> [Lovelace]
 findAllSizes FaucetConfigFile{fcfRecaptchaLimits,fcfApiKeys} = uniq $ values ++ [v]

--- a/src/cardano-faucet/src/Cardano/Faucet/Types.hs
+++ b/src/cardano-faucet/src/Cardano/Faucet/Types.hs
@@ -106,6 +106,8 @@ data FaucetConfigFile = FaucetConfigFile
   , fcfMaxStakeKeyIndex :: Maybe Word32
   , fcfDebug :: Bool
   , fcfDelegationUtxoSize :: Integer
+  , fcfRecaptchaSiteKey :: Text
+  , fcfRecaptchaSecretKey :: Text
   } deriving (Generic, Show)
 
 instance FromJSON FaucetConfigFile where
@@ -118,6 +120,8 @@ instance FromJSON FaucetConfigFile where
     fcfMaxStakeKeyIndex <- o .: "max_stake_key_index"
     fcfDebug <- o .: "debug"
     fcfDelegationUtxoSize <- o .: "delegation_utxo_size"
+    fcfRecaptchaSiteKey <- o .: "recaptcha_site_key"
+    fcfRecaptchaSecretKey <- o .: "recaptcha_secret_key"
     pure FaucetConfigFile{..}
 
 data FaucetValue = Ada Lovelace
@@ -131,7 +135,7 @@ instance ToJSON FaucetValue where
   toJSON (Ada lovelace) = object [ "lovelace" .= lovelace ]
   toJSON (FaucetValueMultiAsset _) = String "unsupported"
 
-data UtxoStats = UtxoStats (Map FaucetValue Integer) deriving Show
+data UtxoStats = UtxoStats (Map FaucetValue Int) deriving Show
 
 data SiteVerifyRequest = SiteVerifyRequest
   { svrSecret :: Text


### PR DESCRIPTION
also improve the response time of /metrics some

this also changes the config file format, 2 new keys must be present, `recaptcha_site_key` and `recaptcha_secret_key`

it also adds 2 optional endpoints, `/basic-faucet` presents a very basic faucet page for testing
`/get-site-key` is used by that page to fetch the `recaptcha_site_key` at runtime

there is also a new config entry for CORS headers, `"allowed_cors_origins":["https://docs.cardano.org"]` that will allow ajax requests from the faucet ui, even when its on a different domain from the faucet backend