### PR TITLE
Benchmarking local Docker backend

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -923,16 +923,16 @@
     "cardano-node": {
       "flake": false,
       "locked": {
-        "lastModified": 1659625017,
-        "narHash": "sha256-4IrheFeoWfvkZQndEk4fGUkOiOjcVhcyXZ6IqmvkDgg=",
+        "lastModified": 1661396426,
+        "narHash": "sha256-pJjj5JG3oUHbgiydH5DoCUZu9sMrrqdM7AS8vOXxwNk=",
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "950c4e222086fed5ca53564e642434ce9307b0b9",
+        "rev": "83c8f8cdcab641b5fd9493f80ad6adfe63542179",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "1.35.3",
+        "ref": "master",
         "repo": "cardano-node",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -57,7 +57,7 @@
     # --- Bride Heads ----------------------------------------------
     # TODO: remove cardano-node (and use self) when mono-repo branch is merged:
     cardano-node = {
-      url = "github:input-output-hk/cardano-node/1.35.3";
+      url = "github:input-output-hk/cardano-node/master";
       flake = false;
     };
     cardano-db-sync.url = "github:input-output-hk/cardano-db-sync/13.0.4";

--- a/nix/cardano/entrypoints.nix
+++ b/nix/cardano/entrypoints.nix
@@ -292,7 +292,9 @@ in {
 
       ${prelude}
 
-      DB_DIR="$DATA_DIR/db-''${ENVIRONMENT:-custom}"
+      if [ -z "''${DB_DIR:-}" ]; then
+        DB_DIR="$DATA_DIR/db-''${ENVIRONMENT:-custom}/node"
+      fi
 
       # the legacy service discovery implementation
       ${legacy-srv-discovery}
@@ -307,12 +309,12 @@ in {
       fi
       if [ -n "''${SNAPSHOT_BASE_URL:-}" ]; then
         pull_snapshot
-        extract_snapshot_tgz_to "$DB_DIR/node" 1
+        extract_snapshot_tgz_to "$DB_DIR" 1
       fi
 
       # Build args array
       args+=("--config" "$NODE_CONFIG")
-      args+=("--database-path" "$DB_DIR/node")
+      args+=("--database-path" "$DB_DIR")
       [ -n "''${HOST_ADDR:-}" ] && args+=("--host-addr" "$HOST_ADDR")
       [ -n "''${HOST_IPV6_ADDR:-}" ] && args+=("--host-ipv6-addr" "$HOST_IPV6_ADDR")
       [ -n "''${PORT:-}" ] && args+=("--port" "$PORT")

--- a/nix/cardano/entrypoints.nix
+++ b/nix/cardano/entrypoints.nix
@@ -371,6 +371,21 @@ in {
     '';
   };
 
+  tx-generator = writeShellApplication {
+    runtimeInputs = [nixpkgs.coreutils nixpkgs.jq];
+    debugInputs = [packages.tx-generator];
+    name = "entrypoint";
+    text = ''
+      [ -z "''${TX_GEN_CONFIG:-}" ] && echo "TX_GEN_CONFIG env var must be set -- aborting" && exit 1
+      args+=("json_highlevel")
+      args+=("$TX_GEN_CONFIG")
+      [ -z "''${HOME:-}" ] && echo "HOME env var must be set -- aborting" && exit 1
+      mkdir -p "$HOME"
+      cd "$HOME"
+      exec ${packages.tx-generator}/bin/tx-generator "''${args[@]}"
+    '';
+  };
+
   cardano-db-sync = writeShellApplication {
     runtimeInputs = prelude-runtime ++ pull-snapshot-deps ++ [nixpkgs.postgresql_12];
     debugInputs = [

--- a/nix/cardano/oci-images.nix
+++ b/nix/cardano/oci-images.nix
@@ -35,6 +35,19 @@ in {
     ];
     config.User = "1000:1000";
   };
+  tx-generator = buildDebugImage entrypoints.tx-generator {
+    name = "registry.ci.iog.io/tx-generator";
+    maxLayers = 25;
+    layers = [
+      (n2c.buildLayer {deps = entrypoints.tx-generator.runtimeInputs;})
+      (n2c.buildLayer {deps = [packages.tx-generator];})
+    ];
+    contents = [nixpkgs.bashInteractive nixpkgs.iana-etc];
+    config.Cmd = [
+      "${entrypoints.tx-generator}/bin/entrypoint"
+    ];
+    config.User = "1000:1000";
+  };
   cardano-db-sync = buildDebugImage entrypoints.cardano-db-sync {
     name = "registry.ci.iog.io/cardano-db-sync";
     maxLayers = 25;

--- a/nix/cardano/oci-images.nix
+++ b/nix/cardano/oci-images.nix
@@ -22,6 +22,19 @@ in {
     ];
     config.User = "1000:1000";
   };
+  cardano-tracer = buildDebugImage entrypoints.cardano-tracer {
+    name = "registry.ci.iog.io/cardano-tracer";
+    maxLayers = 25;
+    layers = [
+      (n2c.buildLayer {deps = entrypoints.cardano-tracer.runtimeInputs;})
+      (n2c.buildLayer {deps = [packages.cardano-tracer];})
+    ];
+    contents = [nixpkgs.bashInteractive nixpkgs.iana-etc];
+    config.Cmd = [
+      "${entrypoints.cardano-tracer}/bin/entrypoint"
+    ];
+    config.User = "1000:1000";
+  };
   cardano-db-sync = buildDebugImage entrypoints.cardano-db-sync {
     name = "registry.ci.iog.io/cardano-db-sync";
     maxLayers = 25;

--- a/nix/cardano/packages/default.nix
+++ b/nix/cardano/packages/default.nix
@@ -109,7 +109,7 @@ let
 in
 {
   inherit project nodeProject ogmiosProject; # TODO REMOVE
-  inherit (nodeProject.exes) cardano-node cardano-cli cardano-submit-api cardano-tracer;
+  inherit (nodeProject.exes) cardano-node cardano-tracer cardano-cli cardano-submit-api;
   inherit (nodeProject.hsPkgs.bech32.components.exes) bech32;
   inherit (nodeProject.hsPkgs.network-mux.components.exes) cardano-ping;
   inherit (project.exes) cardano-new-faucet;

--- a/nix/cardano/packages/default.nix
+++ b/nix/cardano/packages/default.nix
@@ -109,7 +109,7 @@ let
 in
 {
   inherit project nodeProject ogmiosProject; # TODO REMOVE
-  inherit (nodeProject.exes) cardano-node cardano-tracer cardano-cli cardano-submit-api;
+  inherit (nodeProject.exes) cardano-node cardano-tracer tx-generator cardano-cli cardano-submit-api;
   inherit (nodeProject.hsPkgs.bech32.components.exes) bech32;
   inherit (nodeProject.hsPkgs.network-mux.components.exes) cardano-ping;
   inherit (project.exes) cardano-new-faucet;


### PR DESCRIPTION
WIP: Changes needed to run a **local** workbench cluster using the Docker backend
- Add parameter arguments to `cardano-node`:
- - ``--tracer-socket-path-connect``
- - ``--shutdown-on-slot-synced``
- - ``--shutdown-on-block-synced``
- As ``--database-path`` we need to provide a full path (absolute or relative) and it was always adding ``${ENVIRONMENT:-custom}/node`` as suffix. One solution could be to use an special case inside the `prelude` but that means that a lot of code has to be repeated.
- Add ``cardano-tracer`` OCI image and entrypoints
- Add ``tx-generator`` OCI image and entrypoints

The flake changes are still here to discuss how to generate images for different versions efficiently. I needed the latest master to avoid the ``The name ""slotsMissed"" is already taken by a metric.`` error! 