### PR TITLE
implement tokens and partially switch the query client

### DIFF
--- a/nix/cardano/devshellProfiles.nix
+++ b/nix/cardano/devshellProfiles.nix
@@ -60,14 +60,14 @@ rec {
       #  name = "hlint";
       #  category = "development";
       #}
-      #{
-      #  package = haskell-nix.tool compiler-nix-name "ghcid" {
-      #    version = "0.8.7";
-      #    inherit index-state;
-      #  };
-      #  name = "ghcid";
-      #  category = "development";
-      #}
+      {
+        package = haskell-nix.tool compiler-nix-name "ghcid" {
+          version = "0.8.7";
+          inherit index-state;
+        };
+        name = "ghcid";
+        category = "development";
+      }
       #{
       #  package = haskell-nix.tool compiler-nix-name "haskell-language-server" {
       #    version = "1.6.1.1";

--- a/nix/cardano/environments/default.nix
+++ b/nix/cardano/environments/default.nix
@@ -157,6 +157,7 @@
           port = 30001;
         }
       ];
+      edgePort = 30001;
       submitApiConfig = mkSubmitApiConfig "vasil-dev" nodeConfig;
       dbSyncConfig = mkDbSyncConfig "vasil-dev" nodeConfig;
       usePeersFromLedgerAfterSlot = 60000;

--- a/nix/cardano/library.nix
+++ b/nix/cardano/library.nix
@@ -86,6 +86,7 @@ in rec {
       legacyTopology = mkEdgeTopology {
         edgeNodes = [env.relaysNew];
         valency = 2;
+        edgePort = env.edgePort or 3001;
       };
       p2pTopology = mkEdgeTopologyP2P {
         inherit (env) edgeNodes;

--- a/nix/cardano/packages/haskell.nix
+++ b/nix/cardano/packages/haskell.nix
@@ -63,7 +63,7 @@ in
       # *all* dependencies are provided by Nix.
       exactDeps = true;
 
-      withHoogle = false;
+      withHoogle = true;
     };
     modules =
       let

--- a/src/cardano-faucet/src/Cardano/Faucet.hs
+++ b/src/cardano-faucet/src/Cardano/Faucet.hs
@@ -228,7 +228,7 @@ newFaucetState fsConfig fsTxQueue = do
   fsRootKey <- mnemonicToRootKey $ fcfMnemonic fsConfig
   let
     fsAcctKey = rootKeytoAcctKey fsRootKey 0x80000000
-    addrK = accountKeyToPaymentKey fsAcctKey 0x14
+    addrK = accountKeyToPaymentKey fsAcctKey (fcfAddressIndex fsConfig)
     pay_skey = PaymentExtendedSigningKey $ getKey addrK
     pay_vkey = getVerificationKey pay_skey
     fsPaymentSkey = APaymentExtendedSigningKey pay_skey

--- a/src/cardano-faucet/src/Cardano/Faucet/Misc.hs
+++ b/src/cardano-faucet/src/Cardano/Faucet/Misc.hs
@@ -30,6 +30,12 @@ toFaucetValue :: ApiKeyValue -> FaucetValue
 toFaucetValue (ApiKeyValue _ lovelace _ Nothing _) = Ada lovelace
 toFaucetValue (ApiKeyValue _ ll _ (Just t) _) = FaucetValueMultiAsset ll t
 
+stripMintingTokens :: FaucetValue -> FaucetValue
+stripMintingTokens fv@(Ada _) = fv
+stripMintingTokens fv@(FaucetValueMultiAsset _ (FaucetToken _)) = fv
+stripMintingTokens (FaucetValueMultiAsset ll (FaucetMintToken _)) = Ada ll
+stripMintingTokens fv@(FaucetValueManyTokens _) = fv
+
 -- returns just the lovelace component and ignores tokens
 faucetValueToLovelace :: FaucetValue -> Lovelace
 faucetValueToLovelace (Ada ll) = ll

--- a/src/cardano-faucet/src/Cardano/Faucet/TxUtils.hs
+++ b/src/cardano-faucet/src/Cardano/Faucet/TxUtils.hs
@@ -4,7 +4,7 @@
 
 module Cardano.Faucet.TxUtils where
 
-import Cardano.Api (Lovelace(Lovelace), IsShelleyBasedEra, ShelleyBasedEra, NetworkId, TxIn, TxOut(TxOut), CtxUTxO, TxBody, TxBodyContent(TxBodyContent), Witness(KeyWitness), KeyWitnessInCtx(KeyWitnessForSpending), TxInsCollateral(TxInsCollateralNone), TxInsReference(TxInsReferenceNone), TxTotalCollateral(TxTotalCollateralNone), TxReturnCollateral(TxReturnCollateralNone), TxMetadataInEra(TxMetadataNone), TxAuxScripts(TxAuxScriptsNone), TxExtraKeyWitnesses(TxExtraKeyWitnessesNone), TxWithdrawals(TxWithdrawalsNone), TxCertificates, BuildTxWith(BuildTxWith), TxUpdateProposal(TxUpdateProposalNone), TxMintValue(..), TxScriptValidity(TxScriptValidityNone), shelleyBasedToCardanoEra, Tx, makeShelleyKeyWitness, makeSignedTransaction, AddressAny, TxId, getTxId, BuildTx)
+import Cardano.Api (Lovelace, IsShelleyBasedEra, ShelleyBasedEra, NetworkId, TxIn, TxOut(TxOut), CtxUTxO, TxBody, TxBodyContent(TxBodyContent), Witness(KeyWitness), KeyWitnessInCtx(KeyWitnessForSpending), TxInsCollateral(TxInsCollateralNone), TxInsReference(TxInsReferenceNone), TxTotalCollateral(TxTotalCollateralNone), TxReturnCollateral(TxReturnCollateralNone), TxMetadataInEra(TxMetadataNone), TxAuxScripts(TxAuxScriptsNone), TxExtraKeyWitnesses(TxExtraKeyWitnessesNone), TxWithdrawals(TxWithdrawalsNone), TxCertificates, BuildTxWith(BuildTxWith), TxUpdateProposal(TxUpdateProposalNone), TxMintValue(..), TxScriptValidity(TxScriptValidityNone), shelleyBasedToCardanoEra, Tx, makeShelleyKeyWitness, makeSignedTransaction, AddressAny, TxId, getTxId, BuildTx)
 import Cardano.CLI.Shelley.Run.Transaction
 import Cardano.Api.Shelley (lovelaceToValue, makeTransactionBody, Value)
 import Cardano.CLI.Types
@@ -18,18 +18,20 @@ getMintedValue :: TxMintValue BuildTx era -> Value
 getMintedValue (TxMintValue _ val _) = val
 getMintedValue (TxMintNone) = mempty
 
+newtype Fee = Fee Lovelace
+
 txBuild :: IsShelleyBasedEra era
   => ShelleyBasedEra era
   -> (TxIn, TxOut CtxUTxO era)
-  -> TxOutChangeAddress
+  -> Either AddressAny [TxOutAnyEra]
   -> TxCertificates BuildTx era
   -> TxMintValue BuildTx era
+  -> Fee
   -> ExceptT FaucetWebError IO (TxBody era)
-txBuild sbe (txin, txout) (TxOutChangeAddress changeAddr) certs minting = do
+txBuild sbe (txin, txout) addressOrOutputs certs minting (Fee fixedFee) = do
   let
     --localNodeConnInfo = LocalNodeConnectInfo cModeParams networkId sockPath
     era = shelleyBasedToCardanoEra sbe
-    fixedFee = Lovelace 200000
     unwrap :: TxOut ctx1 era1 -> FaucetValue
     unwrap (TxOut _ val _ _) = getValue val
     value :: Lovelace
@@ -41,11 +43,15 @@ txBuild sbe (txin, txout) (TxOutChangeAddress changeAddr) certs minting = do
     changeValue :: Value
     changeValue = (lovelaceToValue change) <> mintedValue
 
+    getTxOuts :: Either AddressAny [TxOutAnyEra] -> [TxOutAnyEra]
+    getTxOuts (Left addr) = [ TxOutAnyEra addr changeValue TxOutDatumByNone ReferenceScriptAnyEraNone ]
+    getTxOuts (Right outs) = outs
+
   txBodyContent <- TxBodyContent
     <$> pure [(txin, BuildTxWith $ KeyWitness KeyWitnessForSpending)]
     <*> pure TxInsCollateralNone
     <*> pure TxInsReferenceNone
-    <*> mapM (\x -> withExceptT (FaucetWebErrorTodo . renderShelleyTxCmdError) $ toTxOutInAnyEra era x) [ (TxOutAnyEra changeAddr changeValue TxOutDatumByNone ReferenceScriptAnyEraNone) ]
+    <*> mapM (\x -> withExceptT (FaucetWebErrorTodo . renderShelleyTxCmdError) $ toTxOutInAnyEra era x) (getTxOuts addressOrOutputs)
     <*> pure TxTotalCollateralNone
     <*> pure TxReturnCollateralNone
     <*> validateTxFee era (Just fixedFee)
@@ -126,16 +132,17 @@ txSign networkId txBody sks = do
 makeAndSignTx :: IsShelleyBasedEra era
   => ShelleyBasedEra era
   -> (TxIn, TxOut CtxUTxO era)
-  -> AddressAny
+  -> Either AddressAny [TxOutAnyEra]
   -> NetworkId
   -> [SomeWitness]
   -> TxCertificates BuildTx era
   -> TxMintValue BuildTx era
+  -> Fee
   -> ExceptT FaucetWebError IO (Tx era, TxId)
-makeAndSignTx sbe txinout addressAny network skeys certs minting = do
+makeAndSignTx sbe txinout addressOrOutputs network skeys certs minting fee = do
   -- instead of having to specify an output that is exactly equal to input-fees
   -- i specify no outputs, and set the change addr to the end-user
-  unsignedTx <- txBuild sbe txinout (TxOutChangeAddress addressAny) certs minting
+  unsignedTx <- txBuild sbe txinout addressOrOutputs certs minting fee
   let
     txid :: TxId
     txid = getTxId unsignedTx

--- a/src/cardano-faucet/src/Cardano/Faucet/Types.hs
+++ b/src/cardano-faucet/src/Cardano/Faucet/Types.hs
@@ -184,6 +184,7 @@ data FaucetConfigFile = FaucetConfigFile
   , fcfRecaptchaSiteKey :: SiteKey
   , fcfRecaptchaSecretKey :: SecretKey
   , fcfAllowedCorsOrigins :: [Text]
+  , fcfAddressIndex :: Word32
   } deriving (Generic, Show)
 
 instance FromJSON FaucetConfigFile where
@@ -199,6 +200,7 @@ instance FromJSON FaucetConfigFile where
     fcfRecaptchaSiteKey <- SiteKey <$> o .: "recaptcha_site_key"
     fcfRecaptchaSecretKey <- SecretKey <$> o .: "recaptcha_secret_key"
     fcfAllowedCorsOrigins <- o .: "allowed_cors_origins"
+    fcfAddressIndex <- fromMaybe 0 <$> o .:? "address_index"
     pure FaucetConfigFile{..}
 
 -- a value with only ada, or a value containing a mix of assets

--- a/src/cardano-faucet/src/Cardano/Faucet/Types.hs
+++ b/src/cardano-faucet/src/Cardano/Faucet/Types.hs
@@ -100,12 +100,12 @@ data ApiKey = Recaptcha Text | ApiKey Text deriving (Ord, Eq)
 
 -- the state of the entire faucet
 data IsCardanoEra era => FaucetState era = FaucetState
-  { utxoTMVar :: TMVar (Map TxIn (TxOut CtxUTxO era))
-  , stakeTMVar :: TMVar ([(Word32, SigningKey StakeExtendedKey, StakeCredential)], [(Word32, Lovelace, PoolId)])
-  , network :: NetworkId
-  , queue :: TQueue (TxInMode CardanoMode, ByteString)
-  , skey :: SomeWitness
-  , vkey :: SomeAddressVerificationKey
+  { fsUtxoTMVar :: TMVar (Map TxIn (TxOut CtxUTxO era))
+  , fsStakeTMVar :: TMVar ([(Word32, SigningKey StakeExtendedKey, StakeCredential)], [(Word32, Lovelace, PoolId)])
+  , fsNetwork :: NetworkId
+  , fsTxQueue :: TQueue (TxInMode CardanoMode, ByteString)
+  , fsPaymentSkey :: SomeWitness
+  , fsPaymentVkey :: SomeAddressVerificationKey
   , fsAcctKey :: Shelley 'AccountK XPrv
   , fsConfig :: FaucetConfigFile
   , fsSendMoneyRateLimitState :: TMVar (Map ApiKey (Map RateLimitAddress UTCTime))

--- a/src/cardano-faucet/src/Cardano/Faucet/Types.hs
+++ b/src/cardano-faucet/src/Cardano/Faucet/Types.hs
@@ -11,7 +11,7 @@ module Cardano.Faucet.Types where
 import Cardano.Address.Derivation (Depth(RootK, AccountK, PaymentK, PolicyK), XPrv, genMasterKeyFromMnemonic, indexFromWord32, deriveAccountPrivateKey, deriveAddressPrivateKey, Index, DerivationType(Hardened, Soft))
 import Cardano.Address.Style.Shelley (Shelley, Role(UTxOExternal, Stake), derivePolicyPrivateKey)
 import Cardano.Api (AnyCardanoEra, IsCardanoEra, TxIn, TxOut, CtxUTxO, NetworkId, TxInMode, CardanoMode, TxId, FileError, Lovelace, AddressAny(AddressByron, AddressShelley), NetworkId, AssetId(AssetId, AdaAssetId), Quantity, SigningKey, getVerificationKey, makeByronAddress, castVerificationKey, PaymentExtendedKey)
-import Cardano.Api.Shelley (PoolId, StakeExtendedKey, StakeCredential, AssetName)
+import Cardano.Api.Shelley (PoolId, StakeExtendedKey, StakeCredential, AssetName(..))
 import Cardano.CLI.Environment (EnvSocketError)
 import Cardano.CLI.Shelley.Key (InputDecodeError)
 import Cardano.CLI.Shelley.Run.Address (SomeAddressVerificationKey(AByronVerificationKey, APaymentVerificationKey, APaymentExtendedVerificationKey, AGenesisUTxOVerificationKey), ShelleyAddressCmdError, buildShelleyAddress)
@@ -258,12 +258,12 @@ instance FromJSON FaucetToken where
         policyid <- v .: "policy_id"
         quantity <- v .: "quantity"
         token <- v .: "token"
-        pure $ FaucetToken (AssetId policyid token,quantity)
+        pure $ FaucetToken (AssetId policyid (AssetName $ encodeUtf8 token),quantity)
       False -> do
         policy_index <- v .: "policy_index"
         token <- v .: "token"
         quantity <- v .: "quantity"
-        pure $ FaucetMintToken (policy_index, token, quantity)
+        pure $ FaucetMintToken (policy_index, AssetName $ encodeUtf8 token, quantity)
 
 instance ToJSON FaucetToken where
   toJSON (FaucetToken (AssetId policyid token, quant)) = object [ "policy_id" .= policyid, "quantity" .= quant, "token" .= token ]

--- a/src/cardano-faucet/src/Cardano/Faucet/Types.hs
+++ b/src/cardano-faucet/src/Cardano/Faucet/Types.hs
@@ -212,7 +212,7 @@ data FaucetValue = Ada Lovelace
 
 instance ToJSON FaucetValue where
   toJSON (Ada lovelace) = object [ "lovelace" .= lovelace ]
-  toJSON (FaucetValueMultiAsset _ _) = String "unsupported"
+  toJSON (FaucetValueMultiAsset _ _) = String "TODO"
   toJSON (FaucetValueManyTokens _) = String "unsupported"
 
 data UtxoStats = UtxoStats (Map FaucetValue Int) deriving Show

--- a/src/cardano-faucet/src/Cardano/Faucet/Types.hs
+++ b/src/cardano-faucet/src/Cardano/Faucet/Types.hs
@@ -278,7 +278,7 @@ instance FromJSON FaucetToken where
 instance ToJSON FaucetToken where
   toJSON (FaucetToken (AssetId policyid token, quant)) = object [ "policy_id" .= policyid, "quantity" .= quant, "token" .= token ]
   toJSON (FaucetToken (AdaAssetId, quant)) = object [ "assetid" .= ("ada" :: Text), "quantity" .= quant ]
-  toJSON (FaucetMintToken (_policyid, _token, _quant)) = undefined
+  toJSON (FaucetMintToken (_policyid, _token, _quant)) = String "TODO"
 
 -- TODO, find a better way to do this
 jsonOptions :: Options


### PR DESCRIPTION
```json
    {
      "api_key": "api_key3",
      "lovelace":10000000,
      "rate_limit":60,
      "tokens":{
        "policy_id":"a017b400af36e7a5269e2f98a642adf27a5a3a36b6e198cb38d8dd39",
        "token":"Testtoken",
        "quantity":100
      }
    }
```
by specifying a policyid, tokenname, and quantity in the rate limit config, the faucet will send that much of the given token in each request

```json
    {
      "api_key":"mint_new1",
      "lovelace":10000000,
      "rate_limit":60,
      "tokens":{
        "policy_index":0,
        "token":"TokenOne",
        "quantity":100
      }
    }
```
by specifying a policy index instead of a policy id, the faucet will derive a policy key at that index, and mint tokens on demand

token names can also be supplied in hex:
```json
    {
      "api_key":"mint_new2",
      "lovelace":10000000,
      "rate_limit":60,
      "tokens":{
        "policy_index":0,
        "tokenHex":"546f6b656e54776f",
        "quantity":100
      }
    }
```
and there is a new top-level config for the address index during key derivation
`"address_index":20`
the default is 0