### PR TITLE
cardano.entrypoints: Enable overriding haskell.nix evalSystem.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3101,11 +3101,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658222743,
-        "narHash": "sha256-yFH01psqx30y5Ws4dBElLkxYpIxxqZx4G+jCVhsXpnA=",
+        "lastModified": 1663072120,
+        "narHash": "sha256-npRp5ULHI8/dvDAkBvudLybz0/vVBHg0p7ps7myxKgk=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "9a604d01bd4420ab7f396f14d1947fbe2ce7db8b",
+        "rev": "e936cc0972fceb544dd7847e39fbcace1c9c00de",
         "type": "github"
       },
       "original": {

--- a/nix/cardano/entrypoints.nix
+++ b/nix/cardano/entrypoints.nix
@@ -6,6 +6,9 @@
   inherit (inputs.bitte-cells._writers.library) writeShellApplication;
   inherit (inputs.bitte-cells._utils.packages) srvaddr;
   inherit (cell) packages environments library constants;
+  packages' = packages;
+in nixpkgs.lib.makeOverridable ({ evalSystem ? throw "unreachable" }@args: let
+  packages = if args ? evalSystem then packages'.override { inherit evalSystem; } else packages';
 
   prelude-runtime = [nixpkgs.coreutils nixpkgs.curl nixpkgs.jq nixpkgs.xxd srvaddr];
 
@@ -598,4 +601,4 @@ in {
       exec ${packages.cardano-new-faucet}/bin/cardano-new-faucet
     '';
   };
-}
+}) {}

--- a/nix/cardano/packages/default.nix
+++ b/nix/cardano/packages/default.nix
@@ -20,6 +20,7 @@ let
   inherit (inputs.cells) cardano;
   inherit (nixpkgs) lib;
 
+in lib.makeOverridable ({ evalSystem ? nixpkgs.system }: let
   inherit
     (import inputs.nixpkgs-haskell {
       inherit (nixpkgs) system;
@@ -30,7 +31,7 @@ let
         crypto
         (final: prev: {
           haskellBuildUtils = prev.haskellBuildUtils.override {
-            inherit compiler-nix-name index-state;
+            inherit compiler-nix-name index-state evalSystem;
           };
         })
       ];
@@ -42,7 +43,7 @@ let
 
   project =
     (import ./haskell.nix {
-      inherit lib haskell-nix;
+      inherit lib haskell-nix evalSystem;
       inherit (inputs) byron-chain;
       src = self;
     });
@@ -137,4 +138,4 @@ in
     cardano.library.generateStaticHTMLConfigs environments;
   cardano-config-html-internal = cardano.library.generateStaticHTMLConfigs cardano.environments;
   inherit nix-inclusive; # TODO REMOVE
-}
+}) {}

--- a/nix/cardano/packages/haskell.nix
+++ b/nix/cardano/packages/haskell.nix
@@ -6,6 +6,7 @@
 , # cabal.project directory
   src
 , byron-chain
+, evalSystem
 }:
 let
 
@@ -65,6 +66,7 @@ in
 
       withHoogle = true;
     };
+    inherit evalSystem;
     modules =
       let
         inherit (config) src;


### PR DESCRIPTION
This enables hydra evaluation for non-Linux systems.