### PR TITLE
nomadCharts: add ellipsis

### DIFF
--- a/nix/cardano/nomadCharts/cardano-db-sync.nix
+++ b/nix/cardano/nomadCharts/cardano-db-sync.nix
@@ -19,6 +19,7 @@ in
     extraVector ? {},
     nodeClass,
     scaling,
+    ...
   } @ args: let
     id = jobname;
     type = "service";

--- a/nix/cardano/nomadCharts/cardano-faucet.nix
+++ b/nix/cardano/nomadCharts/cardano-faucet.nix
@@ -17,6 +17,7 @@ in
     extraVector ? {},
     nodeClass,
     scaling,
+    ...
   } @ args: let
     id = jobname;
     type = "service";

--- a/nix/cardano/nomadCharts/cardano-node.nix
+++ b/nix/cardano/nomadCharts/cardano-node.nix
@@ -18,6 +18,7 @@ in
     extraVector ? {},
     nodeClass,
     scaling,
+    ...
   }: let
     id = jobname;
     type = "service";

--- a/nix/cardano/nomadCharts/cardano-wallet.nix
+++ b/nix/cardano/nomadCharts/cardano-wallet.nix
@@ -19,6 +19,7 @@ in
     extraVector ? {},
     nodeClass,
     scaling,
+    ...
   } @ args: let
     id = jobname;
     type = "service";

--- a/nix/cardano/nomadCharts/ogmios.nix
+++ b/nix/cardano/nomadCharts/ogmios.nix
@@ -17,6 +17,7 @@ in
     extraVector ? {},
     nodeClass,
     scaling,
+    ...
   } @ args: let
     id = jobname;
     type = "service";


### PR DESCRIPTION
For downstream consumers who may define their own constants, they can be safely passed in and simply ignored.