### PR TITLE
flake: Update std input

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -4,8 +4,6 @@
 [[ -f .envrc.local ]] && source_env .envrc.local
 DEVSHELL_TARGET=${DEVSHELL_TARGET:-dev}
 
-source_url \
-  "https://raw.githubusercontent.com/divnix/std/main/direnv_lib.sh" \
-  "sha256-gnjtiJpKbz4L4udoK12AvBwL1lo5RqPR9mbLu1zuajw="
+source "$(nix eval .#__std.direnv_lib)"
 use std nix //automation/devshells:${DEVSHELL_TARGET}
 

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,10 @@ dist-newstyle/
 workbench
 
 # nixago: ignore-linked-files
+.editorconfig
 adrgen.config.yml
 lefthook.yml
 treefmt.toml
 .conform.yaml
+# nixago-auto-created: mdbook-build-folder
+book/**

--- a/book.toml
+++ b/book.toml
@@ -1,17 +1,8 @@
 [book]
 autors = ["The Cardano Authors"]
-language = "en"
-multilingual = false
-src = "docs"
 title = "The Cardano Operations Book"
-
-[build]
-build-dir = "docs/book"
 
 [output.html]
 edit-url-template = "https://github.com/input-output-hk/cardano-world/edit/master/src/{path}"
 git-repository-icon = "fa-github"
 git-repository-url = "https://github.com/input-output-hk/cardano-world"
-
-[preprocessor.kroki-preprocessor]
-command = "mdbook-kroki-preprocessor"

--- a/flake.lock
+++ b/flake.lock
@@ -3918,11 +3918,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659153038,
-        "narHash": "sha256-g4npRU8YBR7CAqMF0SyXtkHnoY9q+NcxvZwcc6UvLBc=",
+        "lastModified": 1661824785,
+        "narHash": "sha256-/PnwdWoO/JugJZHtDUioQp3uRiWeXHUdgvoyNbXesz8=",
         "owner": "nix-community",
         "repo": "nixago",
-        "rev": "608abdd0fe6729d1f7244e03f1a7f8a5d6408898",
+        "rev": "8c1f9e5f1578d4b2ea989f618588d62a335083c3",
         "type": "github"
       },
       "original": {
@@ -6215,11 +6215,11 @@
         "yants": "yants_4"
       },
       "locked": {
-        "lastModified": 1661367957,
-        "narHash": "sha256-5B94aTocy6Y6ZJFmzkGdPmg6L6gjNaMVAKcpsaw44Ns=",
+        "lastModified": 1662862782,
+        "narHash": "sha256-D5wn3uQRNuQsFT/g2rliHkUDraJVpYsvYqr6l2MCWVY=",
         "owner": "divnix",
         "repo": "std",
-        "rev": "d39794e19e648b840e5a56aa1f354d43aee9abf7",
+        "rev": "bff0e737b872af59ba70fdf6e06b7dc212156d17",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -90,7 +90,7 @@
       inherit inputs;
       cellsFrom = ./nix;
       #debug = ["cells" "cloud" "packages"];
-      organelles = [
+      cellBlocks = [
         (inputs.std.data "constants")
         (inputs.std.data "environments")
         (inputs.std.data "namespaces/infra")


### PR DESCRIPTION
Also switch .envrc to using flake output instead of hardcoded hash.

We're getting a warning about std terminology from bitte-cells with this.