### PR TITLE
fix: user '0:0' error, bump bitte to master

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -518,7 +518,7 @@
     "alejandra": {
       "inputs": {
         "flakeCompat": "flakeCompat",
-        "nixpkgs": "nixpkgs_23"
+        "nixpkgs": "nixpkgs_22"
       },
       "locked": {
         "lastModified": 1646360966,
@@ -593,16 +593,15 @@
         "utils": "utils_4"
       },
       "locked": {
-        "lastModified": 1674869506,
-        "narHash": "sha256-2S4585ZLjkG//wYA7cIniNBnEWRDOyi4CjTmlb5vs9E=",
+        "lastModified": 1675703137,
+        "narHash": "sha256-pIn6uOHkwdJkPESKWT3asESsG8UOMhKtWwNmcpADUTg=",
         "owner": "input-output-hk",
         "repo": "bitte",
-        "rev": "4c86138bb9c8f02abf12528231e1c52e5a21ae3e",
+        "rev": "02ecec6a67e732f6b26f80da4927845d99884442",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "nixpkgs-2211",
         "repo": "bitte",
         "type": "github"
       }
@@ -615,9 +614,9 @@
         "cardano-wallet": "cardano-wallet",
         "cicero": "cicero",
         "data-merge": "data-merge_3",
-        "n2c": "n2c_2",
-        "nixpkgs": "nixpkgs_30",
-        "std": "std_3"
+        "n2c": "n2c_3",
+        "nixpkgs": "nixpkgs_29",
+        "std": "std_2"
       },
       "locked": {
         "lastModified": 1670003309,
@@ -664,6 +663,21 @@
       }
     },
     "blank_3": {
+      "locked": {
+        "lastModified": 1625557891,
+        "narHash": "sha256-O8/MWsPBGhhyPoPLHZAuoZiiHo9q6FLlEeIDEXuj6T4=",
+        "owner": "divnix",
+        "repo": "blank",
+        "rev": "5a5d2684073d9f563072ed07c871d577a6c614a8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "blank",
+        "type": "github"
+      }
+    },
+    "blank_4": {
       "locked": {
         "lastModified": 1625557891,
         "narHash": "sha256-O8/MWsPBGhhyPoPLHZAuoZiiHo9q6FLlEeIDEXuj6T4=",
@@ -1890,7 +1904,7 @@
           "bitte"
         ],
         "iogo": "iogo",
-        "nixpkgs": "nixpkgs_33",
+        "nixpkgs": "nixpkgs_32",
         "ragenix": "ragenix_2"
       },
       "locked": {
@@ -1999,7 +2013,7 @@
     },
     "cardano-iohk-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_16"
+        "nixpkgs": "nixpkgs_15"
       },
       "locked": {
         "lastModified": 1649070135,
@@ -2017,7 +2031,7 @@
     },
     "cardano-mainnet-mirror": {
       "inputs": {
-        "nixpkgs": "nixpkgs_17"
+        "nixpkgs": "nixpkgs_16"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -2036,7 +2050,7 @@
     },
     "cardano-mainnet-mirror_10": {
       "inputs": {
-        "nixpkgs": "nixpkgs_47"
+        "nixpkgs": "nixpkgs_46"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -2055,7 +2069,7 @@
     },
     "cardano-mainnet-mirror_11": {
       "inputs": {
-        "nixpkgs": "nixpkgs_48"
+        "nixpkgs": "nixpkgs_47"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -2074,7 +2088,7 @@
     },
     "cardano-mainnet-mirror_12": {
       "inputs": {
-        "nixpkgs": "nixpkgs_49"
+        "nixpkgs": "nixpkgs_48"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -2093,7 +2107,7 @@
     },
     "cardano-mainnet-mirror_13": {
       "inputs": {
-        "nixpkgs": "nixpkgs_50"
+        "nixpkgs": "nixpkgs_49"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -2112,7 +2126,7 @@
     },
     "cardano-mainnet-mirror_2": {
       "inputs": {
-        "nixpkgs": "nixpkgs_36"
+        "nixpkgs": "nixpkgs_35"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -2131,7 +2145,7 @@
     },
     "cardano-mainnet-mirror_3": {
       "inputs": {
-        "nixpkgs": "nixpkgs_39"
+        "nixpkgs": "nixpkgs_38"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -2150,7 +2164,7 @@
     },
     "cardano-mainnet-mirror_4": {
       "inputs": {
-        "nixpkgs": "nixpkgs_41"
+        "nixpkgs": "nixpkgs_40"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -2169,7 +2183,7 @@
     },
     "cardano-mainnet-mirror_5": {
       "inputs": {
-        "nixpkgs": "nixpkgs_42"
+        "nixpkgs": "nixpkgs_41"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -2188,7 +2202,7 @@
     },
     "cardano-mainnet-mirror_6": {
       "inputs": {
-        "nixpkgs": "nixpkgs_43"
+        "nixpkgs": "nixpkgs_42"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -2207,7 +2221,7 @@
     },
     "cardano-mainnet-mirror_7": {
       "inputs": {
-        "nixpkgs": "nixpkgs_44"
+        "nixpkgs": "nixpkgs_43"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -2226,7 +2240,7 @@
     },
     "cardano-mainnet-mirror_8": {
       "inputs": {
-        "nixpkgs": "nixpkgs_45"
+        "nixpkgs": "nixpkgs_44"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -2245,7 +2259,7 @@
     },
     "cardano-mainnet-mirror_9": {
       "inputs": {
-        "nixpkgs": "nixpkgs_46"
+        "nixpkgs": "nixpkgs_45"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -3078,7 +3092,7 @@
         "customConfig": "customConfig_3",
         "emanote": "emanote",
         "flake-compat": "flake-compat_7",
-        "flake-utils": "flake-utils_15",
+        "flake-utils": "flake-utils_14",
         "haskellNix": "haskellNix_3",
         "hostNixpkgs": [
           "bitte-cells",
@@ -3113,7 +3127,7 @@
         "ema": "ema_2",
         "emanote": "emanote_2",
         "flake-compat": "flake-compat_16",
-        "flake-utils": "flake-utils_45",
+        "flake-utils": "flake-utils_44",
         "haskellNix": "haskellNix_23",
         "hostNixpkgs": [
           "cardano-wallet",
@@ -3145,14 +3159,14 @@
       "inputs": {
         "alejandra": "alejandra",
         "data-merge": "data-merge_2",
-        "devshell": "devshell_4",
+        "devshell": "devshell_3",
         "driver": "driver",
         "follower": "follower",
         "haskell-nix": "haskell-nix",
         "inclusive": "inclusive_4",
         "nix": "nix_3",
         "nix-cache-proxy": "nix-cache-proxy",
-        "nixpkgs": "nixpkgs_27",
+        "nixpkgs": "nixpkgs_26",
         "poetry2nix": "poetry2nix",
         "utils": "utils_10"
       },
@@ -3547,7 +3561,7 @@
     "data-merge_3": {
       "inputs": {
         "nixlib": "nixlib_3",
-        "yants": "yants_4"
+        "yants": "yants_3"
       },
       "locked": {
         "lastModified": 1659548052,
@@ -3592,7 +3606,7 @@
     "deploy-rs": {
       "inputs": {
         "flake-compat": "flake-compat_17",
-        "nixpkgs": "nixpkgs_57",
+        "nixpkgs": "nixpkgs_56",
         "utils": "utils_31"
       },
       "locked": {
@@ -3625,31 +3639,6 @@
       }
     },
     "devshell_10": {
-      "inputs": {
-        "flake-utils": [
-          "std",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "std",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1663445644,
-        "narHash": "sha256-+xVlcK60x7VY1vRJbNUEAHi17ZuoQxAIH4S4iUFUGBA=",
-        "owner": "numtide",
-        "repo": "devshell",
-        "rev": "e3dc3e21594fe07bdb24bdf1c8657acaa4cb8f66",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "devshell",
-        "type": "github"
-      }
-    },
-    "devshell_11": {
       "inputs": {
         "flake-utils": [
           "tullia",
@@ -3690,11 +3679,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658746384,
-        "narHash": "sha256-CCJcoMOcXyZFrV1ag4XMTpAPjLWb4Anbv+ktXFI1ry0=",
+        "lastModified": 1663445644,
+        "narHash": "sha256-+xVlcK60x7VY1vRJbNUEAHi17ZuoQxAIH4S4iUFUGBA=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "0ffc7937bb5e8141af03d462b468bd071eb18e1b",
+        "rev": "e3dc3e21594fe07bdb24bdf1c8657acaa4cb8f66",
         "type": "github"
       },
       "original": {
@@ -3705,32 +3694,8 @@
     },
     "devshell_3": {
       "inputs": {
-        "flake-utils": "flake-utils_7",
-        "nixpkgs": [
-          "bitte",
-          "tullia",
-          "std",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1650900878,
-        "narHash": "sha256-qhNncMBSa9STnhiLfELEQpYC1L4GrYHNIzyCZ/pilsI=",
-        "owner": "numtide",
-        "repo": "devshell",
-        "rev": "d97df53b5ddaa1cfbea7cddbd207eb2634304733",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "devshell",
-        "type": "github"
-      }
-    },
-    "devshell_4": {
-      "inputs": {
-        "flake-utils": "flake-utils_17",
-        "nixpkgs": "nixpkgs_24"
+        "flake-utils": "flake-utils_16",
+        "nixpkgs": "nixpkgs_23"
       },
       "locked": {
         "lastModified": 1644227066,
@@ -3746,13 +3711,28 @@
         "type": "github"
       }
     },
-    "devshell_5": {
+    "devshell_4": {
       "locked": {
         "lastModified": 1632436039,
         "narHash": "sha256-OtITeVWcKXn1SpVEnImpTGH91FycCskGBPqmlxiykv4=",
         "owner": "numtide",
         "repo": "devshell",
         "rev": "7a7a7aa0adebe5488e5abaec688fd9ae0f8ea9c6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "devshell_5": {
+      "locked": {
+        "lastModified": 1636119665,
+        "narHash": "sha256-e11Z9PyH9hdgTm4Vyl8S5iTwrv0um6+srzb1Ba+YUHA=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "ab14b1a3cb253f58e02f5f849d621292fbf81fad",
         "type": "github"
       },
       "original": {
@@ -3777,21 +3757,6 @@
       }
     },
     "devshell_7": {
-      "locked": {
-        "lastModified": 1636119665,
-        "narHash": "sha256-e11Z9PyH9hdgTm4Vyl8S5iTwrv0um6+srzb1Ba+YUHA=",
-        "owner": "numtide",
-        "repo": "devshell",
-        "rev": "ab14b1a3cb253f58e02f5f849d621292fbf81fad",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "devshell",
-        "type": "github"
-      }
-    },
-    "devshell_8": {
       "inputs": {
         "flake-utils": [
           "bitte-cells",
@@ -3818,13 +3783,38 @@
         "type": "github"
       }
     },
-    "devshell_9": {
+    "devshell_8": {
       "locked": {
         "lastModified": 1637098489,
         "narHash": "sha256-IWBYLSNSENI/fTrXdYDhuCavxcgN9+RERrPM81f6DXY=",
         "owner": "numtide",
         "repo": "devshell",
         "rev": "e8c2d4967b5c498b12551d1bb49352dcf9efa3e4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "devshell_9": {
+      "inputs": {
+        "flake-utils": [
+          "std",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "std",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1663445644,
+        "narHash": "sha256-+xVlcK60x7VY1vRJbNUEAHi17ZuoQxAIH4S4iUFUGBA=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "e3dc3e21594fe07bdb24bdf1c8657acaa4cb8f66",
         "type": "github"
       },
       "original": {
@@ -3941,7 +3931,7 @@
     },
     "driver": {
       "inputs": {
-        "devshell": "devshell_5",
+        "devshell": "devshell_4",
         "inclusive": "inclusive_2",
         "nix": "nix_2",
         "nixpkgs": [
@@ -3968,8 +3958,8 @@
     "ema": {
       "inputs": {
         "flake-compat": "flake-compat_3",
-        "flake-utils": "flake-utils_10",
-        "nixpkgs": "nixpkgs_18",
+        "flake-utils": "flake-utils_9",
+        "nixpkgs": "nixpkgs_17",
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
@@ -3990,8 +3980,8 @@
     "ema_2": {
       "inputs": {
         "flake-compat": "flake-compat_15",
-        "flake-utils": "flake-utils_42",
-        "nixpkgs": "nixpkgs_51",
+        "flake-utils": "flake-utils_41",
+        "nixpkgs": "nixpkgs_50",
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
@@ -4029,9 +4019,9 @@
       "inputs": {
         "ema": "ema",
         "flake-compat": "flake-compat_4",
-        "flake-utils": "flake-utils_12",
+        "flake-utils": "flake-utils_11",
         "heist": "heist",
-        "nixpkgs": "nixpkgs_20",
+        "nixpkgs": "nixpkgs_19",
         "tailwind-haskell": "tailwind-haskell"
       },
       "locked": {
@@ -4053,7 +4043,7 @@
         "ema": "ema_3",
         "flake-parts": "flake-parts",
         "haskell-flake": "haskell-flake",
-        "nixpkgs": "nixpkgs_54",
+        "nixpkgs": "nixpkgs_53",
         "tailwind-haskell": "tailwind-haskell_2"
       },
       "locked": {
@@ -4468,7 +4458,7 @@
     },
     "flake-parts": {
       "inputs": {
-        "nixpkgs": "nixpkgs_53"
+        "nixpkgs": "nixpkgs_52"
       },
       "locked": {
         "lastModified": 1655570068,
@@ -4519,21 +4509,6 @@
     },
     "flake-utils_10": {
       "locked": {
-        "lastModified": 1642700792,
-        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_11": {
-      "locked": {
         "lastModified": 1619345332,
         "narHash": "sha256-qHnQkEp1uklKTpx3MvKtY6xzgcqXDsz5nLilbbuL+3A=",
         "owner": "numtide",
@@ -4547,7 +4522,7 @@
         "type": "github"
       }
     },
-    "flake-utils_12": {
+    "flake-utils_11": {
       "locked": {
         "lastModified": 1638122382,
         "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
@@ -4562,13 +4537,28 @@
         "type": "github"
       }
     },
-    "flake-utils_13": {
+    "flake-utils_12": {
       "locked": {
         "lastModified": 1642700792,
         "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_13": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
         "type": "github"
       },
       "original": {
@@ -4594,21 +4584,6 @@
     },
     "flake-utils_15": {
       "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_16": {
-      "locked": {
         "lastModified": 1623875721,
         "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
         "owner": "numtide",
@@ -4622,7 +4597,7 @@
         "type": "github"
       }
     },
-    "flake-utils_17": {
+    "flake-utils_16": {
       "locked": {
         "lastModified": 1642700792,
         "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
@@ -4637,7 +4612,7 @@
         "type": "github"
       }
     },
-    "flake-utils_18": {
+    "flake-utils_17": {
       "locked": {
         "lastModified": 1644229661,
         "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
@@ -4652,13 +4627,28 @@
         "type": "github"
       }
     },
-    "flake-utils_19": {
+    "flake-utils_18": {
       "locked": {
         "lastModified": 1610051610,
         "narHash": "sha256-U9rPz/usA1/Aohhk7Cmc2gBrEEKRzcW4nwPWMPwja4Y=",
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "3982c9903e93927c2164caa727cd3f6a0e6d14cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_19": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
         "type": "github"
       },
       "original": {
@@ -4684,11 +4674,11 @@
     },
     "flake-utils_20": {
       "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
         "type": "github"
       },
       "original": {
@@ -4699,11 +4689,11 @@
     },
     "flake-utils_21": {
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
         "type": "github"
       },
       "original": {
@@ -4774,11 +4764,11 @@
     },
     "flake-utils_26": {
       "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
         "type": "github"
       },
       "original": {
@@ -4999,11 +4989,11 @@
     },
     "flake-utils_4": {
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -5029,21 +5019,6 @@
     },
     "flake-utils_41": {
       "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_42": {
-      "locked": {
         "lastModified": 1642700792,
         "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
         "owner": "numtide",
@@ -5057,7 +5032,7 @@
         "type": "github"
       }
     },
-    "flake-utils_43": {
+    "flake-utils_42": {
       "locked": {
         "lastModified": 1619345332,
         "narHash": "sha256-qHnQkEp1uklKTpx3MvKtY6xzgcqXDsz5nLilbbuL+3A=",
@@ -5072,7 +5047,7 @@
         "type": "github"
       }
     },
-    "flake-utils_44": {
+    "flake-utils_43": {
       "locked": {
         "lastModified": 1652776076,
         "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
@@ -5088,13 +5063,28 @@
         "type": "github"
       }
     },
-    "flake-utils_45": {
+    "flake-utils_44": {
       "locked": {
         "lastModified": 1653893745,
         "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_45": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
         "type": "github"
       },
       "original": {
@@ -5120,11 +5110,11 @@
     },
     "flake-utils_47": {
       "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -5150,11 +5140,11 @@
     },
     "flake-utils_49": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
         "type": "github"
       },
       "original": {
@@ -5179,21 +5169,6 @@
       }
     },
     "flake-utils_50": {
-      "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_51": {
       "locked": {
         "lastModified": 1659877975,
         "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
@@ -5225,11 +5200,11 @@
     },
     "flake-utils_7": {
       "locked": {
-        "lastModified": 1642700792,
-        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
         "type": "github"
       },
       "original": {
@@ -5255,11 +5230,11 @@
     },
     "flake-utils_9": {
       "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "lastModified": 1642700792,
+        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
         "type": "github"
       },
       "original": {
@@ -5286,7 +5261,7 @@
     },
     "follower": {
       "inputs": {
-        "devshell": "devshell_6",
+        "devshell": "devshell_5",
         "inclusive": "inclusive_3",
         "nixpkgs": [
           "bitte-cells",
@@ -5755,7 +5730,7 @@
     },
     "gomod2nix_2": {
       "inputs": {
-        "nixpkgs": "nixpkgs_61",
+        "nixpkgs": "nixpkgs_60",
         "utils": "utils_32"
       },
       "locked": {
@@ -6210,7 +6185,7 @@
         "cabal-34": "cabal-34_4",
         "cabal-36": "cabal-36_3",
         "cardano-shell": "cardano-shell_4",
-        "flake-utils": "flake-utils_18",
+        "flake-utils": "flake-utils_17",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_4",
         "hackage": "hackage_4",
         "hpc-coveralls": "hpc-coveralls_4",
@@ -6254,7 +6229,7 @@
         "cabal-36": "cabal-36_20",
         "cardano-shell": "cardano-shell_25",
         "flake-compat": "flake-compat_19",
-        "flake-utils": "flake-utils_47",
+        "flake-utils": "flake-utils_46",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_25",
         "hackage": [
           "hackage"
@@ -6293,7 +6268,7 @@
         "cabal-32": "cabal-32",
         "cabal-34": "cabal-34",
         "cardano-shell": "cardano-shell",
-        "flake-utils": "flake-utils_8",
+        "flake-utils": "flake-utils_7",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
         "hackage": "hackage",
         "hpc-coveralls": "hpc-coveralls",
@@ -6332,7 +6307,7 @@
         "cabal-34": "cabal-34_11",
         "cabal-36": "cabal-36_10",
         "cardano-shell": "cardano-shell_11",
-        "flake-utils": "flake-utils_29",
+        "flake-utils": "flake-utils_28",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_11",
         "hackage": "hackage_10",
         "hpc-coveralls": "hpc-coveralls_11",
@@ -6373,7 +6348,7 @@
         "cabal-34": "cabal-34_12",
         "cabal-36": "cabal-36_11",
         "cardano-shell": "cardano-shell_12",
-        "flake-utils": "flake-utils_30",
+        "flake-utils": "flake-utils_29",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_12",
         "hackage": "hackage_11",
         "hpc-coveralls": "hpc-coveralls_12",
@@ -6415,7 +6390,7 @@
         "cabal-32": "cabal-32_13",
         "cabal-34": "cabal-34_13",
         "cardano-shell": "cardano-shell_13",
-        "flake-utils": "flake-utils_31",
+        "flake-utils": "flake-utils_30",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_13",
         "hackage": "hackage_12",
         "hpc-coveralls": "hpc-coveralls_13",
@@ -6457,7 +6432,7 @@
         "cabal-34": "cabal-34_14",
         "cabal-36": "cabal-36_12",
         "cardano-shell": "cardano-shell_14",
-        "flake-utils": "flake-utils_32",
+        "flake-utils": "flake-utils_31",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_14",
         "hackage": "hackage_13",
         "hpc-coveralls": "hpc-coveralls_14",
@@ -6496,7 +6471,7 @@
         "cabal-34": "cabal-34_15",
         "cabal-36": "cabal-36_13",
         "cardano-shell": "cardano-shell_15",
-        "flake-utils": "flake-utils_33",
+        "flake-utils": "flake-utils_32",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_15",
         "hackage": "hackage_14",
         "hpc-coveralls": "hpc-coveralls_15",
@@ -6537,7 +6512,7 @@
         "cabal-34": "cabal-34_16",
         "cabal-36": "cabal-36_14",
         "cardano-shell": "cardano-shell_16",
-        "flake-utils": "flake-utils_34",
+        "flake-utils": "flake-utils_33",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_16",
         "hackage": "hackage_15",
         "hpc-coveralls": "hpc-coveralls_16",
@@ -6579,7 +6554,7 @@
         "cabal-32": "cabal-32_17",
         "cabal-34": "cabal-34_17",
         "cardano-shell": "cardano-shell_17",
-        "flake-utils": "flake-utils_35",
+        "flake-utils": "flake-utils_34",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_17",
         "hackage": "hackage_16",
         "hpc-coveralls": "hpc-coveralls_17",
@@ -6621,7 +6596,7 @@
         "cabal-34": "cabal-34_18",
         "cabal-36": "cabal-36_15",
         "cardano-shell": "cardano-shell_18",
-        "flake-utils": "flake-utils_36",
+        "flake-utils": "flake-utils_35",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_18",
         "hackage": "hackage_17",
         "hpc-coveralls": "hpc-coveralls_18",
@@ -6660,7 +6635,7 @@
         "cabal-34": "cabal-34_19",
         "cabal-36": "cabal-36_16",
         "cardano-shell": "cardano-shell_19",
-        "flake-utils": "flake-utils_37",
+        "flake-utils": "flake-utils_36",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_19",
         "hackage": "hackage_18",
         "hpc-coveralls": "hpc-coveralls_19",
@@ -6700,7 +6675,7 @@
         "cabal-32": "cabal-32_20",
         "cabal-34": "cabal-34_20",
         "cardano-shell": "cardano-shell_20",
-        "flake-utils": "flake-utils_38",
+        "flake-utils": "flake-utils_37",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_20",
         "hackage": "hackage_19",
         "hpc-coveralls": "hpc-coveralls_20",
@@ -6740,7 +6715,7 @@
         "cabal-34": "cabal-34_2",
         "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell_2",
-        "flake-utils": "flake-utils_9",
+        "flake-utils": "flake-utils_8",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_2",
         "hackage": "hackage_2",
         "hpc-coveralls": "hpc-coveralls_2",
@@ -6778,7 +6753,7 @@
         "cabal-34": "cabal-34_21",
         "cabal-36": "cabal-36_17",
         "cardano-shell": "cardano-shell_21",
-        "flake-utils": "flake-utils_39",
+        "flake-utils": "flake-utils_38",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_21",
         "hackage": "hackage_20",
         "hpc-coveralls": "hpc-coveralls_21",
@@ -6816,7 +6791,7 @@
         "cabal-34": "cabal-34_22",
         "cabal-36": "cabal-36_18",
         "cardano-shell": "cardano-shell_22",
-        "flake-utils": "flake-utils_40",
+        "flake-utils": "flake-utils_39",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_22",
         "hackage": "hackage_21",
         "hpc-coveralls": "hpc-coveralls_22",
@@ -6855,7 +6830,7 @@
         "cabal-32": "cabal-32_23",
         "cabal-34": "cabal-34_23",
         "cardano-shell": "cardano-shell_23",
-        "flake-utils": "flake-utils_41",
+        "flake-utils": "flake-utils_40",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_23",
         "hackage": "hackage_22",
         "hpc-coveralls": "hpc-coveralls_23",
@@ -6894,7 +6869,7 @@
         "cabal-34": "cabal-34_24",
         "cabal-36": "cabal-36_19",
         "cardano-shell": "cardano-shell_24",
-        "flake-utils": "flake-utils_46",
+        "flake-utils": "flake-utils_45",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_24",
         "hackage": "hackage_23",
         "hpc-coveralls": "hpc-coveralls_24",
@@ -6932,7 +6907,7 @@
         "cabal-34": "cabal-34_3",
         "cabal-36": "cabal-36_2",
         "cardano-shell": "cardano-shell_3",
-        "flake-utils": "flake-utils_16",
+        "flake-utils": "flake-utils_15",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_3",
         "hackage": "hackage_3",
         "hpc-coveralls": "hpc-coveralls_3",
@@ -6970,7 +6945,7 @@
         "cabal-34": "cabal-34_5",
         "cabal-36": "cabal-36_4",
         "cardano-shell": "cardano-shell_5",
-        "flake-utils": "flake-utils_23",
+        "flake-utils": "flake-utils_22",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_5",
         "hackage": "hackage_5",
         "hpc-coveralls": "hpc-coveralls_5",
@@ -7009,7 +6984,7 @@
         "cabal-34": "cabal-34_6",
         "cabal-36": "cabal-36_5",
         "cardano-shell": "cardano-shell_6",
-        "flake-utils": "flake-utils_24",
+        "flake-utils": "flake-utils_23",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_6",
         "hackage": "hackage_6",
         "hpc-coveralls": "hpc-coveralls_6",
@@ -7049,7 +7024,7 @@
         "cabal-36": "cabal-36_6",
         "cardano-shell": "cardano-shell_7",
         "flake-compat": "flake-compat_10",
-        "flake-utils": "flake-utils_25",
+        "flake-utils": "flake-utils_24",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_7",
         "hackage": [
           "cardano-node",
@@ -7090,7 +7065,7 @@
         "cabal-34": "cabal-34_8",
         "cabal-36": "cabal-36_7",
         "cardano-shell": "cardano-shell_8",
-        "flake-utils": "flake-utils_26",
+        "flake-utils": "flake-utils_25",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_8",
         "hackage": "hackage_7",
         "hpc-coveralls": "hpc-coveralls_8",
@@ -7130,7 +7105,7 @@
         "cabal-34": "cabal-34_9",
         "cabal-36": "cabal-36_8",
         "cardano-shell": "cardano-shell_9",
-        "flake-utils": "flake-utils_27",
+        "flake-utils": "flake-utils_26",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_9",
         "hackage": "hackage_8",
         "hpc-coveralls": "hpc-coveralls_9",
@@ -7168,7 +7143,7 @@
         "cabal-34": "cabal-34_10",
         "cabal-36": "cabal-36_9",
         "cardano-shell": "cardano-shell_10",
-        "flake-utils": "flake-utils_28",
+        "flake-utils": "flake-utils_27",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_10",
         "hackage": "hackage_9",
         "hpc-coveralls": "hpc-coveralls_10",
@@ -7766,6 +7741,7 @@
     "incl": {
       "inputs": {
         "nixlib": [
+          "bitte",
           "std",
           "nixpkgs"
         ]
@@ -7785,6 +7761,27 @@
       }
     },
     "incl_2": {
+      "inputs": {
+        "nixlib": [
+          "std",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1669263024,
+        "narHash": "sha256-E/+23NKtxAqYG/0ydYgxlgarKnxmDbg6rCMWnOBqn9Q=",
+        "owner": "divnix",
+        "repo": "incl",
+        "rev": "ce7bebaee048e4cd7ebdb4cee7885e00c4e2abca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "incl",
+        "type": "github"
+      }
+    },
+    "incl_3": {
       "inputs": {
         "nixlib": [
           "tullia",
@@ -7898,9 +7895,9 @@
     },
     "iogo": {
       "inputs": {
-        "devshell": "devshell_9",
+        "devshell": "devshell_8",
         "inclusive": "inclusive_5",
-        "nixpkgs": "nixpkgs_32",
+        "nixpkgs": "nixpkgs_31",
         "utils": "utils_11"
       },
       "locked": {
@@ -8636,22 +8633,6 @@
         "type": "github"
       }
     },
-    "mdbook-kroki-preprocessor_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1655670640,
-        "narHash": "sha256-JjqdxftHBjABTkOpFl3cWUJtc/KGwkQ3NRWGLjH2oUs=",
-        "owner": "JoelCourtney",
-        "repo": "mdbook-kroki-preprocessor",
-        "rev": "bb6e607437ecc3f22fd9036acee6b797a5b45dbc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "JoelCourtney",
-        "repo": "mdbook-kroki-preprocessor",
-        "type": "github"
-      }
-    },
     "membench": {
       "inputs": {
         "cardano-mainnet-mirror": "cardano-mainnet-mirror",
@@ -9168,8 +9149,35 @@
     },
     "n2c_2": {
       "inputs": {
-        "flake-utils": "flake-utils_20",
-        "nixpkgs": "nixpkgs_29"
+        "flake-utils": [
+          "bitte",
+          "std",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "bitte",
+          "std",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1665039323,
+        "narHash": "sha256-SAh3ZjFGsaCI8FRzXQyp56qcGdAqgKEfJWPCQ0Sr7tQ=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "b008fe329ffb59b67bf9e7b08ede6ee792f2741a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "type": "github"
+      }
+    },
+    "n2c_3": {
+      "inputs": {
+        "flake-utils": "flake-utils_19",
+        "nixpkgs": "nixpkgs_28"
       },
       "locked": {
         "lastModified": 1664348923,
@@ -9185,7 +9193,7 @@
         "type": "github"
       }
     },
-    "n2c_3": {
+    "n2c_4": {
       "inputs": {
         "flake-utils": [
           "std",
@@ -9210,7 +9218,7 @@
         "type": "github"
       }
     },
-    "n2c_4": {
+    "n2c_5": {
       "inputs": {
         "flake-utils": [
           "tullia",
@@ -9239,7 +9247,7 @@
     },
     "napalm": {
       "inputs": {
-        "flake-utils": "flake-utils_48",
+        "flake-utils": "flake-utils_47",
         "nixpkgs": [
           "openziti",
           "nixpkgs"
@@ -9282,7 +9290,7 @@
     },
     "nix-cache-proxy": {
       "inputs": {
-        "devshell": "devshell_7",
+        "devshell": "devshell_6",
         "inclusive": [
           "bitte-cells",
           "cicero",
@@ -9783,8 +9791,8 @@
     },
     "nix2container_2": {
       "inputs": {
-        "flake-utils": "flake-utils_50",
-        "nixpkgs": "nixpkgs_62"
+        "flake-utils": "flake-utils_49",
+        "nixpkgs": "nixpkgs_61"
       },
       "locked": {
         "lastModified": 1658567952,
@@ -9835,7 +9843,7 @@
     "nix_2": {
       "inputs": {
         "lowdown-src": "lowdown-src_2",
-        "nixpkgs": "nixpkgs_25",
+        "nixpkgs": "nixpkgs_24",
         "nixpkgs-regression": "nixpkgs-regression_2"
       },
       "locked": {
@@ -9856,7 +9864,7 @@
     "nix_3": {
       "inputs": {
         "lowdown-src": "lowdown-src_3",
-        "nixpkgs": "nixpkgs_26",
+        "nixpkgs": "nixpkgs_25",
         "nixpkgs-regression": "nixpkgs-regression_3"
       },
       "locked": {
@@ -9877,7 +9885,7 @@
     "nix_4": {
       "inputs": {
         "lowdown-src": "lowdown-src_4",
-        "nixpkgs": "nixpkgs_35",
+        "nixpkgs": "nixpkgs_34",
         "nixpkgs-regression": "nixpkgs-regression_4"
       },
       "locked": {
@@ -9898,7 +9906,7 @@
     "nix_5": {
       "inputs": {
         "lowdown-src": "lowdown-src_5",
-        "nixpkgs": "nixpkgs_37",
+        "nixpkgs": "nixpkgs_36",
         "nixpkgs-regression": "nixpkgs-regression_5"
       },
       "locked": {
@@ -9919,7 +9927,7 @@
     "nix_6": {
       "inputs": {
         "lowdown-src": "lowdown-src_6",
-        "nixpkgs": "nixpkgs_38",
+        "nixpkgs": "nixpkgs_37",
         "nixpkgs-regression": "nixpkgs-regression_6"
       },
       "locked": {
@@ -9940,7 +9948,7 @@
     "nix_7": {
       "inputs": {
         "lowdown-src": "lowdown-src_7",
-        "nixpkgs": "nixpkgs_40",
+        "nixpkgs": "nixpkgs_39",
         "nixpkgs-regression": "nixpkgs-regression_7"
       },
       "locked": {
@@ -9961,7 +9969,7 @@
     "nix_8": {
       "inputs": {
         "lowdown-src": "lowdown-src_8",
-        "nixpkgs": "nixpkgs_56",
+        "nixpkgs": "nixpkgs_55",
         "nixpkgs-regression": "nixpkgs-regression_8"
       },
       "locked": {
@@ -9982,7 +9990,7 @@
     "nix_9": {
       "inputs": {
         "lowdown-src": "lowdown-src_9",
-        "nixpkgs": "nixpkgs_58",
+        "nixpkgs": "nixpkgs_57",
         "nixpkgs-regression": "nixpkgs-regression_9"
       },
       "locked": {
@@ -10007,7 +10015,11 @@
           "std",
           "flake-utils"
         ],
-        "nixago-exts": "nixago-exts",
+        "nixago-exts": [
+          "bitte",
+          "std",
+          "blank"
+        ],
         "nixpkgs": [
           "bitte",
           "std",
@@ -10043,21 +10055,6 @@
         "type": "github"
       }
     },
-    "nixago-exts_2": {
-      "locked": {
-        "lastModified": 1625557891,
-        "narHash": "sha256-O8/MWsPBGhhyPoPLHZAuoZiiHo9q6FLlEeIDEXuj6T4=",
-        "owner": "divnix",
-        "repo": "blank",
-        "rev": "5a5d2684073d9f563072ed07c871d577a6c614a8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixago-extensions",
-        "type": "github"
-      }
-    },
     "nixago_2": {
       "inputs": {
         "flake-utils": [
@@ -10065,7 +10062,7 @@
           "std",
           "flake-utils"
         ],
-        "nixago-exts": "nixago-exts_2",
+        "nixago-exts": "nixago-exts",
         "nixpkgs": [
           "bitte-cells",
           "std",
@@ -12042,11 +12039,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1658311025,
-        "narHash": "sha256-GqagY5YmaZB3YaO41kKcQhe5RcpS83wnsW8iCu5Znqo=",
+        "lastModified": 1665087388,
+        "narHash": "sha256-FZFPuW9NWHJteATOf79rZfwfRn5fE0wi9kRzvGfDHPA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cd8d1784506a7c7eb0796772b73437e0b82fad57",
+        "rev": "95fda953f6db2e9496d2682c4fc7b82f959878f7",
         "type": "github"
       },
       "original": {
@@ -12089,37 +12086,21 @@
     },
     "nixpkgs_14": {
       "locked": {
-        "lastModified": 1672580127,
-        "narHash": "sha256-3lW3xZslREhJogoOkjeZtlBtvFMyxHku7I/9IVehhT8=",
+        "lastModified": 1674407282,
+        "narHash": "sha256-2qwc8mrPINSFdWffPK+ji6nQ9aGnnZyHSItVcYDZDlk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0874168639713f547c05947c76124f78441ea46c",
+        "rev": "ab1254087f4cdf4af74b552d7fc95175d9bdbb49",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-22.05",
+        "ref": "nixos-22.11",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_15": {
-      "locked": {
-        "lastModified": 1650469885,
-        "narHash": "sha256-BuILRZ6pzMnGey8/irbjGq1oo3vIvZa1pitSdZCmIXA=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "df78cc4e2a46fca75d14508a5d2ed3494add28ff",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_16": {
       "locked": {
         "lastModified": 1648219316,
         "narHash": "sha256-Ctij+dOi0ZZIfX5eMhgwugfvB+WZSrvVNAyAuANOsnQ=",
@@ -12133,7 +12114,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_17": {
+    "nixpkgs_16": {
       "locked": {
         "lastModified": 1642336556,
         "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
@@ -12147,7 +12128,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_18": {
+    "nixpkgs_17": {
       "locked": {
         "lastModified": 1641521701,
         "narHash": "sha256-IuW+4EqqKjNdJ4yO0Qr8k63OkyV1TaF5vsrZzU3GCfI=",
@@ -12163,7 +12144,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_19": {
+    "nixpkgs_18": {
       "locked": {
         "lastModified": 1619531122,
         "narHash": "sha256-ovm5bo6PkZzNKh2YGXbRKYIjega0EjiEP0YDwyeXEYU=",
@@ -12175,6 +12156,22 @@
       "original": {
         "id": "nixpkgs",
         "type": "indirect"
+      }
+    },
+    "nixpkgs_19": {
+      "locked": {
+        "lastModified": 1641521701,
+        "narHash": "sha256-IuW+4EqqKjNdJ4yO0Qr8k63OkyV1TaF5vsrZzU3GCfI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d77bbfcbb650d9c219ca3286e1efb707b922d7c2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d77bbfcbb650d9c219ca3286e1efb707b922d7c2",
+        "type": "github"
       }
     },
     "nixpkgs_2": {
@@ -12195,22 +12192,6 @@
     },
     "nixpkgs_20": {
       "locked": {
-        "lastModified": 1641521701,
-        "narHash": "sha256-IuW+4EqqKjNdJ4yO0Qr8k63OkyV1TaF5vsrZzU3GCfI=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d77bbfcbb650d9c219ca3286e1efb707b922d7c2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d77bbfcbb650d9c219ca3286e1efb707b922d7c2",
-        "type": "github"
-      }
-    },
-    "nixpkgs_21": {
-      "locked": {
         "lastModified": 1641577433,
         "narHash": "sha256-T7lS8vpbC3dgtrkb2ueC9HWaX4RYUwdP7IEttnvKQ8Y=",
         "owner": "nixos",
@@ -12225,7 +12206,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_22": {
+    "nixpkgs_21": {
       "locked": {
         "lastModified": 1641521701,
         "narHash": "sha256-IuW+4EqqKjNdJ4yO0Qr8k63OkyV1TaF5vsrZzU3GCfI=",
@@ -12239,7 +12220,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_23": {
+    "nixpkgs_22": {
       "locked": {
         "lastModified": 1646331602,
         "narHash": "sha256-cRuytTfel52z947yKfJcZU7zbQBgM16qqTf+oJkVwtg=",
@@ -12255,7 +12236,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_24": {
+    "nixpkgs_23": {
       "locked": {
         "lastModified": 1643381941,
         "narHash": "sha256-pHTwvnN4tTsEKkWlXQ8JMY423epos8wUOhthpwJjtpc=",
@@ -12269,6 +12250,21 @@
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
+      }
+    },
+    "nixpkgs_24": {
+      "locked": {
+        "lastModified": 1632864508,
+        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-21.05-small",
+        "type": "indirect"
       }
     },
     "nixpkgs_25": {
@@ -12288,21 +12284,6 @@
     },
     "nixpkgs_26": {
       "locked": {
-        "lastModified": 1632864508,
-        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-21.05-small",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_27": {
-      "locked": {
         "lastModified": 1644486793,
         "narHash": "sha256-EeijR4guVHgVv+JpOX3cQO+1XdrkJfGmiJ9XVsVU530=",
         "owner": "NixOS",
@@ -12317,7 +12298,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_28": {
+    "nixpkgs_27": {
       "locked": {
         "lastModified": 1660438583,
         "narHash": "sha256-rJUTYxFKlWUJI3njAwEc1pKAVooAViZGJvsgqfh/q/E=",
@@ -12332,7 +12313,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_29": {
+    "nixpkgs_28": {
       "locked": {
         "lastModified": 1654807842,
         "narHash": "sha256-ADymZpr6LuTEBXcy6RtFHcUZdjKTBRTMYwu19WOx17E=",
@@ -12343,6 +12324,22 @@
       },
       "original": {
         "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_29": {
+      "locked": {
+        "lastModified": 1664328665,
+        "narHash": "sha256-MVUhaUYwzrmzD/RzTBEGIpYBmncP3JNvZMjGyXtuX/w=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0c97cb06a5b8f1a266fea43b7335de562ea16d3b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -12364,22 +12361,6 @@
     },
     "nixpkgs_30": {
       "locked": {
-        "lastModified": 1664328665,
-        "narHash": "sha256-MVUhaUYwzrmzD/RzTBEGIpYBmncP3JNvZMjGyXtuX/w=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "0c97cb06a5b8f1a266fea43b7335de562ea16d3b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-22.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_31": {
-      "locked": {
         "lastModified": 1658311025,
         "narHash": "sha256-GqagY5YmaZB3YaO41kKcQhe5RcpS83wnsW8iCu5Znqo=",
         "owner": "nixos",
@@ -12394,7 +12375,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_32": {
+    "nixpkgs_31": {
       "locked": {
         "lastModified": 1646506091,
         "narHash": "sha256-sWNAJE2m+HOh1jtXlHcnhxsj6/sXrHgbqVNcVRlveK4=",
@@ -12410,7 +12391,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_33": {
+    "nixpkgs_32": {
       "locked": {
         "lastModified": 1658119717,
         "narHash": "sha256-4upOZIQQ7Bc4CprqnHsKnqYfw+arJeAuU+QcpjYBXW0=",
@@ -12426,7 +12407,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_34": {
+    "nixpkgs_33": {
       "locked": {
         "lastModified": 1644525281,
         "narHash": "sha256-D3VuWLdnLmAXIkooWAtbTGSQI9Fc1lkvAr94wTxhnTU=",
@@ -12442,7 +12423,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_35": {
+    "nixpkgs_34": {
       "locked": {
         "lastModified": 1632864508,
         "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
@@ -12457,7 +12438,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_36": {
+    "nixpkgs_35": {
       "locked": {
         "lastModified": 1642336556,
         "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
@@ -12468,6 +12449,21 @@
       },
       "original": {
         "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_36": {
+      "locked": {
+        "lastModified": 1632864508,
+        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-21.05-small",
         "type": "indirect"
       }
     },
@@ -12488,6 +12484,20 @@
     },
     "nixpkgs_38": {
       "locked": {
+        "lastModified": 1642336556,
+        "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f3d9d4bd898cca7d04af2ae4f6ef01f2219df3d6",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_39": {
+      "locked": {
         "lastModified": 1632864508,
         "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
         "owner": "NixOS",
@@ -12498,20 +12508,6 @@
       "original": {
         "id": "nixpkgs",
         "ref": "nixos-21.05-small",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_39": {
-      "locked": {
-        "lastModified": 1642336556,
-        "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f3d9d4bd898cca7d04af2ae4f6ef01f2219df3d6",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
         "type": "indirect"
       }
     },
@@ -12533,16 +12529,15 @@
     },
     "nixpkgs_40": {
       "locked": {
-        "lastModified": 1632864508,
-        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
+        "lastModified": 1642336556,
+        "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
+        "rev": "f3d9d4bd898cca7d04af2ae4f6ef01f2219df3d6",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-21.05-small",
         "type": "indirect"
       }
     },
@@ -12690,20 +12685,6 @@
     },
     "nixpkgs_50": {
       "locked": {
-        "lastModified": 1642336556,
-        "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f3d9d4bd898cca7d04af2ae4f6ef01f2219df3d6",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_51": {
-      "locked": {
         "lastModified": 1646470760,
         "narHash": "sha256-dQISyucVCCPaFioUhy5ZgfBz8rOMKGI8k13aPDFTqEs=",
         "owner": "nixos",
@@ -12718,7 +12699,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_52": {
+    "nixpkgs_51": {
       "locked": {
         "lastModified": 1619531122,
         "narHash": "sha256-ovm5bo6PkZzNKh2YGXbRKYIjega0EjiEP0YDwyeXEYU=",
@@ -12732,7 +12713,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_53": {
+    "nixpkgs_52": {
       "locked": {
         "lastModified": 1656461576,
         "narHash": "sha256-rlmmw6lIlkMQIiB+NsnO8wQYWTfle8TA41UREPLP5VY=",
@@ -12748,7 +12729,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_54": {
+    "nixpkgs_53": {
       "locked": {
         "lastModified": 1655567057,
         "narHash": "sha256-Cc5hQSMsTzOHmZnYm8OSJ5RNUp22bd5NADWLHorULWQ=",
@@ -12762,7 +12743,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_55": {
+    "nixpkgs_54": {
       "locked": {
         "lastModified": 1656401090,
         "narHash": "sha256-bUS2nfQsvTQW2z8SK7oEFSElbmoBahOPtbXPm0AL3I4=",
@@ -12776,7 +12757,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_56": {
+    "nixpkgs_55": {
       "locked": {
         "lastModified": 1632864508,
         "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
@@ -12791,7 +12772,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_57": {
+    "nixpkgs_56": {
       "locked": {
         "lastModified": 1671417167,
         "narHash": "sha256-JkHam6WQOwZN1t2C2sbp1TqMv3TVRjzrdoejqfefwrM=",
@@ -12807,7 +12788,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_58": {
+    "nixpkgs_57": {
       "locked": {
         "lastModified": 1632864508,
         "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
@@ -12822,7 +12803,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_59": {
+    "nixpkgs_58": {
       "locked": {
         "lastModified": 1665003617,
         "narHash": "sha256-EXkCo9uMi/aGybJ+fhJuCw9mZyyOg24C4d8HrJ/QyFA=",
@@ -12833,6 +12814,22 @@
       },
       "original": {
         "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_59": {
+      "locked": {
+        "lastModified": 1665087388,
+        "narHash": "sha256-FZFPuW9NWHJteATOf79rZfwfRn5fE0wi9kRzvGfDHPA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "95fda953f6db2e9496d2682c4fc7b82f959878f7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -12854,22 +12851,6 @@
     },
     "nixpkgs_60": {
       "locked": {
-        "lastModified": 1665087388,
-        "narHash": "sha256-FZFPuW9NWHJteATOf79rZfwfRn5fE0wi9kRzvGfDHPA=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "95fda953f6db2e9496d2682c4fc7b82f959878f7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_61": {
-      "locked": {
         "lastModified": 1653581809,
         "narHash": "sha256-Uvka0V5MTGbeOfWte25+tfRL3moECDh1VwokWSZUdoY=",
         "owner": "NixOS",
@@ -12884,7 +12865,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_62": {
+    "nixpkgs_61": {
       "locked": {
         "lastModified": 1654807842,
         "narHash": "sha256-ADymZpr6LuTEBXcy6RtFHcUZdjKTBRTMYwu19WOx17E=",
@@ -12899,7 +12880,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_63": {
+    "nixpkgs_62": {
       "locked": {
         "lastModified": 1653920503,
         "narHash": "sha256-BBeCZwZImtjP3oYy4WogkQYy5OxNyfNciVSc1AfZgLQ=",
@@ -12915,7 +12896,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_64": {
+    "nixpkgs_63": {
       "locked": {
         "lastModified": 1665087388,
         "narHash": "sha256-FZFPuW9NWHJteATOf79rZfwfRn5fE0wi9kRzvGfDHPA=",
@@ -13208,6 +13189,21 @@
       }
     },
     "nosys_2": {
+      "locked": {
+        "lastModified": 1667881534,
+        "narHash": "sha256-FhwJ15uPLRsvaxtt/bNuqE/ykMpNAPF0upozFKhTtXM=",
+        "owner": "divnix",
+        "repo": "nosys",
+        "rev": "2d0d5207f6a230e9d0f660903f8db9807b54814f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "nosys",
+        "type": "github"
+      }
+    },
+    "nosys_3": {
       "locked": {
         "lastModified": 1667881534,
         "narHash": "sha256-FhwJ15uPLRsvaxtt/bNuqE/ykMpNAPF0upozFKhTtXM=",
@@ -13669,7 +13665,7 @@
         "flake-compat": "flake-compat_20",
         "flake-parts": "flake-parts_2",
         "napalm": "napalm",
-        "nixpkgs": "nixpkgs_59",
+        "nixpkgs": "nixpkgs_58",
         "zitiConsole": "zitiConsole"
       },
       "locked": {
@@ -14101,7 +14097,7 @@
     },
     "poetry2nix": {
       "inputs": {
-        "flake-utils": "flake-utils_19",
+        "flake-utils": "flake-utils_18",
         "nixpkgs": [
           "bitte-cells",
           "cicero",
@@ -14125,8 +14121,8 @@
     },
     "pre-commit-hooks": {
       "inputs": {
-        "flake-utils": "flake-utils_11",
-        "nixpkgs": "nixpkgs_19"
+        "flake-utils": "flake-utils_10",
+        "nixpkgs": "nixpkgs_18"
       },
       "locked": {
         "lastModified": 1639823344,
@@ -14144,8 +14140,8 @@
     },
     "pre-commit-hooks_2": {
       "inputs": {
-        "flake-utils": "flake-utils_43",
-        "nixpkgs": "nixpkgs_52"
+        "flake-utils": "flake-utils_42",
+        "nixpkgs": "nixpkgs_51"
       },
       "locked": {
         "lastModified": 1639823344,
@@ -14185,8 +14181,8 @@
     "ragenix_2": {
       "inputs": {
         "agenix": "agenix_3",
-        "flake-utils": "flake-utils_22",
-        "nixpkgs": "nixpkgs_34",
+        "flake-utils": "flake-utils_21",
+        "nixpkgs": "nixpkgs_33",
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
@@ -14239,7 +14235,7 @@
         ],
         "ogmios": "ogmios",
         "openziti": "openziti",
-        "std": "std_4",
+        "std": "std_3",
         "tullia": "tullia_2"
       }
     },
@@ -14733,20 +14729,38 @@
     },
     "std": {
       "inputs": {
+        "arion": [
+          "bitte",
+          "std",
+          "blank"
+        ],
+        "blank": "blank_2",
         "devshell": "devshell_2",
         "dmerge": "dmerge",
         "flake-utils": "flake-utils_4",
-        "mdbook-kroki-preprocessor": "mdbook-kroki-preprocessor",
+        "incl": "incl",
+        "makes": [
+          "bitte",
+          "std",
+          "blank"
+        ],
+        "microvm": [
+          "bitte",
+          "std",
+          "blank"
+        ],
+        "n2c": "n2c_2",
         "nixago": "nixago",
         "nixpkgs": "nixpkgs_11",
+        "nosys": "nosys",
         "yants": "yants_2"
       },
       "locked": {
-        "lastModified": 1663105169,
-        "narHash": "sha256-b56/CtEshjHZzT7H8UXZraDU2PnZlWcwmLbfieJWU5U=",
+        "lastModified": 1675651836,
+        "narHash": "sha256-Zv71oPiV2lsO6TJfEqqCAlohAo+OnBZSGZgsALxdCGs=",
         "owner": "divnix",
         "repo": "std",
-        "rev": "4d8613be346a4c9fa28f08b8d30bde21e7f14a60",
+        "rev": "97348aa1056414f1c97caa7e1a4c21efda3f24e5",
         "type": "github"
       },
       "original": {
@@ -14757,33 +14771,13 @@
     },
     "std_2": {
       "inputs": {
-        "devshell": "devshell_3",
-        "nixpkgs": "nixpkgs_15",
-        "yants": "yants_3"
-      },
-      "locked": {
-        "lastModified": 1652784712,
-        "narHash": "sha256-ofwGapSWqzUVgIxwwmjlrOVogfjV4yd6WpY8fNfMc2o=",
-        "owner": "divnix",
-        "repo": "std",
-        "rev": "3667d2d868352b0bf47c83440da48bee9f2fab47",
-        "type": "github"
-      },
-      "original": {
-        "owner": "divnix",
-        "repo": "std",
-        "type": "github"
-      }
-    },
-    "std_3": {
-      "inputs": {
-        "devshell": "devshell_8",
+        "devshell": "devshell_7",
         "dmerge": "dmerge_2",
-        "flake-utils": "flake-utils_21",
-        "mdbook-kroki-preprocessor": "mdbook-kroki-preprocessor_2",
+        "flake-utils": "flake-utils_20",
+        "mdbook-kroki-preprocessor": "mdbook-kroki-preprocessor",
         "nixago": "nixago_2",
-        "nixpkgs": "nixpkgs_31",
-        "yants": "yants_5"
+        "nixpkgs": "nixpkgs_30",
+        "yants": "yants_4"
       },
       "locked": {
         "lastModified": 1664063803,
@@ -14799,17 +14793,17 @@
         "type": "github"
       }
     },
-    "std_4": {
+    "std_3": {
       "inputs": {
         "arion": [
           "std",
           "blank"
         ],
-        "blank": "blank_2",
-        "devshell": "devshell_10",
+        "blank": "blank_3",
+        "devshell": "devshell_9",
         "dmerge": "dmerge_3",
-        "flake-utils": "flake-utils_49",
-        "incl": "incl",
+        "flake-utils": "flake-utils_48",
+        "incl": "incl_2",
         "makes": [
           "std",
           "blank"
@@ -14818,11 +14812,11 @@
           "std",
           "blank"
         ],
-        "n2c": "n2c_3",
+        "n2c": "n2c_4",
         "nixago": "nixago_3",
-        "nixpkgs": "nixpkgs_60",
-        "nosys": "nosys",
-        "yants": "yants_6"
+        "nixpkgs": "nixpkgs_59",
+        "nosys": "nosys_2",
+        "yants": "yants_5"
       },
       "locked": {
         "lastModified": 1674068571,
@@ -14838,18 +14832,18 @@
         "type": "github"
       }
     },
-    "std_5": {
+    "std_4": {
       "inputs": {
         "arion": [
           "tullia",
           "std",
           "blank"
         ],
-        "blank": "blank_3",
-        "devshell": "devshell_11",
+        "blank": "blank_4",
+        "devshell": "devshell_10",
         "dmerge": "dmerge_4",
-        "flake-utils": "flake-utils_51",
-        "incl": "incl_2",
+        "flake-utils": "flake-utils_50",
+        "incl": "incl_3",
         "makes": [
           "tullia",
           "std",
@@ -14860,11 +14854,11 @@
           "std",
           "blank"
         ],
-        "n2c": "n2c_4",
+        "n2c": "n2c_5",
         "nixago": "nixago_4",
-        "nixpkgs": "nixpkgs_64",
-        "nosys": "nosys_2",
-        "yants": "yants_7"
+        "nixpkgs": "nixpkgs_63",
+        "nosys": "nosys_3",
+        "yants": "yants_6"
       },
       "locked": {
         "lastModified": 1673226500,
@@ -14973,8 +14967,8 @@
     "tailwind-haskell": {
       "inputs": {
         "flake-compat": "flake-compat_5",
-        "flake-utils": "flake-utils_13",
-        "nixpkgs": "nixpkgs_21",
+        "flake-utils": "flake-utils_12",
+        "nixpkgs": "nixpkgs_20",
         "tailwind-nix": "tailwind-nix"
       },
       "locked": {
@@ -14994,8 +14988,8 @@
     },
     "tailwind-haskell_2": {
       "inputs": {
-        "flake-utils": "flake-utils_44",
-        "nixpkgs": "nixpkgs_55"
+        "flake-utils": "flake-utils_43",
+        "nixpkgs": "nixpkgs_54"
       },
       "locked": {
         "lastModified": 1654211622,
@@ -15015,8 +15009,8 @@
     "tailwind-nix": {
       "inputs": {
         "flake-compat": "flake-compat_6",
-        "flake-utils": "flake-utils_14",
-        "nixpkgs": "nixpkgs_22"
+        "flake-utils": "flake-utils_13",
+        "nixpkgs": "nixpkgs_21"
       },
       "locked": {
         "lastModified": 1641667991,
@@ -15077,14 +15071,17 @@
         "nix-nomad": "nix-nomad",
         "nix2container": "nix2container",
         "nixpkgs": "nixpkgs_14",
-        "std": "std_2"
+        "std": [
+          "bitte",
+          "std"
+        ]
       },
       "locked": {
-        "lastModified": 1663328195,
-        "narHash": "sha256-G3RvHi54nhD0DOoDOQIEB2jDJ/VNPfYMjUiAIaAQJBI=",
+        "lastModified": 1675695930,
+        "narHash": "sha256-B7rEZ/DBUMlK1AcJ9ajnAPPxqXY6zW2SBX+51bZV0Ac=",
         "owner": "input-output-hk",
         "repo": "tullia",
-        "rev": "da1febfc387e6c6c6f204877857109a65c24001b",
+        "rev": "621365f2c725608f381b3ad5b57afef389fd4c31",
         "type": "github"
       },
       "original": {
@@ -15097,8 +15094,8 @@
       "inputs": {
         "nix-nomad": "nix-nomad_2",
         "nix2container": "nix2container_2",
-        "nixpkgs": "nixpkgs_63",
-        "std": "std_5"
+        "nixpkgs": "nixpkgs_62",
+        "std": "std_4"
       },
       "locked": {
         "lastModified": 1673967538,
@@ -15621,11 +15618,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1645126146,
-        "narHash": "sha256-XQ1eg4gzXoc7Tl8iXak1uCt3KnsTyxqPtLE+vOoDnrQ=",
+        "lastModified": 1667096281,
+        "narHash": "sha256-wRRec6ze0gJHmGn6m57/zhz/Kdvp9HS4Nl5fkQ+uIuA=",
         "owner": "divnix",
         "repo": "yants",
-        "rev": "77df2be1b3cce9f571c6cf451f786b266a6869cc",
+        "rev": "d18f356ec25cb94dc9c275870c3a7927a10f8c3c",
         "type": "github"
       },
       "original": {
@@ -15636,30 +15633,7 @@
     },
     "yants_3": {
       "inputs": {
-        "nixpkgs": [
-          "bitte",
-          "tullia",
-          "std",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1645126146,
-        "narHash": "sha256-XQ1eg4gzXoc7Tl8iXak1uCt3KnsTyxqPtLE+vOoDnrQ=",
-        "owner": "divnix",
-        "repo": "yants",
-        "rev": "77df2be1b3cce9f571c6cf451f786b266a6869cc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "divnix",
-        "repo": "yants",
-        "type": "github"
-      }
-    },
-    "yants_4": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_28"
+        "nixpkgs": "nixpkgs_27"
       },
       "locked": {
         "lastModified": 1660507851,
@@ -15675,7 +15649,7 @@
         "type": "github"
       }
     },
-    "yants_5": {
+    "yants_4": {
       "inputs": {
         "nixpkgs": [
           "bitte-cells",
@@ -15697,7 +15671,7 @@
         "type": "github"
       }
     },
-    "yants_6": {
+    "yants_5": {
       "inputs": {
         "nixpkgs": [
           "std",
@@ -15718,7 +15692,7 @@
         "type": "github"
       }
     },
-    "yants_7": {
+    "yants_6": {
       "inputs": {
         "nixpkgs": [
           "tullia",

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
 
     # --- Bitte Stack ----------------------------------------------
     bitte = {
-      url = "github:input-output-hk/bitte/nixpkgs-2211";
+      url = "github:input-output-hk/bitte";
       inputs.capsules.follows = "capsules";
     };
 

--- a/nix/cardano/nomadCharts/cardano-db-sync.nix
+++ b/nix/cardano/nomadCharts/cardano-db-sync.nix
@@ -126,7 +126,6 @@ in
                   env.WORKLOAD_CLIENT_KEY = "/secrets/tls/key.pem";
                   env.WORKLOAD_CLIENT_CERT = "/secrets/tls/cert.pem";
                   config.image = ociNamer oci-images.cardano-db-sync;
-                  user = "0:0";
                   driver = "docker";
                   kill_signal = "SIGINT";
                   kill_timeout = "30s";

--- a/nix/cardano/nomadCharts/cardano-faucet.nix
+++ b/nix/cardano/nomadCharts/cardano-faucet.nix
@@ -150,7 +150,6 @@ in
                   env.WORKLOAD_CLIENT_CERT = "/secrets/tls/cert.pem";
                   config.image = ociNamer oci-images.cardano-faucet;
                   config.ports = ["http"];
-                  user = "0:0";
                   driver = "docker";
                   kill_signal = "SIGINT";
                   kill_timeout = "30s";

--- a/nix/cardano/nomadCharts/cardano-node.nix
+++ b/nix/cardano/nomadCharts/cardano-node.nix
@@ -124,7 +124,6 @@ in
                 env.WORKLOAD_CLIENT_KEY = "/secrets/tls/key.pem";
                 env.WORKLOAD_CLIENT_CERT = "/secrets/tls/cert.pem";
                 config.image = ociNamer oci-images.cardano-node;
-                user = "0:0";
                 driver = "docker";
                 kill_signal = "SIGINT";
                 kill_timeout = "30s";

--- a/nix/cardano/nomadCharts/cardano-wallet.nix
+++ b/nix/cardano/nomadCharts/cardano-wallet.nix
@@ -127,7 +127,6 @@ in
                   env.WORKLOAD_CLIENT_KEY = "/secrets/tls/key.pem";
                   env.WORKLOAD_CLIENT_CERT = "/secrets/tls/cert.pem";
                   config.image = ociNamer oci-images.cardano-wallet;
-                  user = "0:0";
                   driver = "docker";
                   kill_signal = "SIGINT";
                   kill_timeout = "30s";

--- a/nix/cardano/nomadCharts/ogmios.nix
+++ b/nix/cardano/nomadCharts/ogmios.nix
@@ -123,7 +123,6 @@ in
                   env.WORKLOAD_CLIENT_KEY = "/secrets/tls/key.pem";
                   env.WORKLOAD_CLIENT_CERT = "/secrets/tls/cert.pem";
                   config.image = ociNamer oci-images.ogmios;
-                  user = "0:0";
                   driver = "docker";
                   kill_signal = "SIGINT";
                   kill_timeout = "30s";

--- a/nix/cardano/oci-images.nix
+++ b/nix/cardano/oci-images.nix
@@ -19,6 +19,7 @@
   ];
 
   buildDebugImage = ep: o: n2c.buildImage (_utils.library.mkDebugOCI ep o);
+  tmpdir = nixpkgs.runCommand "tmpdir" {} "mkdir -p $out/tmp";
 in {
   cardano-node = buildDebugImage entrypoints.cardano-node {
     name = "registry.ci.iog.io/cardano-node";
@@ -31,7 +32,7 @@ in {
     config.Cmd = [
       "${entrypoints.cardano-node}/bin/entrypoint"
     ];
-    config.User = "1000:1000";
+    config.User = "65534:65534";
   };
   cardano-db-sync = buildDebugImage entrypoints.cardano-db-sync {
     name = "registry.ci.iog.io/cardano-db-sync";
@@ -40,11 +41,18 @@ in {
       (n2c.buildLayer {deps = entrypoints.cardano-db-sync.runtimeInputs;})
       (n2c.buildLayer {deps = [packages.cardano-db-sync];})
     ];
-    copyToRoot = [nixpkgs.bashInteractive nixpkgs.iana-etc rootCACerts];
+    copyToRoot = [nixpkgs.bashInteractive nixpkgs.iana-etc rootCACerts tmpdir];
     config.Cmd = [
       "${entrypoints.cardano-db-sync}/bin/entrypoint"
     ];
-    config.User = "1000:1000";
+    config.User = "65534:65534";
+    perms = [
+      {
+        path = tmpdir;
+        regex = ".*";
+        mode = "1777";
+      }
+    ];
   };
   cardano-wallet = buildDebugImage entrypoints.cardano-wallet {
     name = "registry.ci.iog.io/cardano-wallet";
@@ -57,7 +65,7 @@ in {
     config.Cmd = [
       "${entrypoints.cardano-wallet}/bin/entrypoint"
     ];
-    config.User = "1000:1000";
+    config.User = "65534:65534";
   };
   cardano-submit-api = buildDebugImage entrypoints.cardano-submit-api {
     name = "registry.ci.iog.io/cardano-submit-api";
@@ -70,7 +78,7 @@ in {
     config.Cmd = [
       "${entrypoints.cardano-submit-api}/bin/entrypoint"
     ];
-    config.User = "1000:1000";
+    config.User = "65534:65534";
   };
   ogmios = buildDebugImage entrypoints.ogmios {
     name = "registry.ci.iog.io/ogmios";
@@ -83,7 +91,7 @@ in {
     config.Cmd = [
       "${entrypoints.ogmios}/bin/entrypoint"
     ];
-    config.User = "1000:1000";
+    config.User = "65534:65534";
   };
   cardano-faucet = buildDebugImage entrypoints.cardano-faucet {
     name = "registry.ci.iog.io/cardano-faucet";
@@ -95,6 +103,6 @@ in {
     config.Cmd = [
       "${entrypoints.cardano-faucet}/bin/entrypoint"
     ];
-    config.User = "1000:1000";
+    config.User = "65534:65534";
   };
 }

--- a/nix/cloud/kv/vault/.sops.yaml
+++ b/nix/cloud/kv/vault/.sops.yaml
@@ -26,6 +26,8 @@ creation_rules:
     hc_vault_transit_uri: "https://vault.world.dev.cardano.org/v1/sops/keys/ops"
   - path_regex: db-sync/mainnet*
     hc_vault_transit_uri: "https://vault.world.dev.cardano.org/v1/sops/keys/ops"
+  - path_regex: db-sync/private*
+    hc_vault_transit_uri: "https://vault.world.dev.cardano.org/v1/sops/keys/ops"
   - path_regex: faucet/vasil-dev*
     hc_vault_transit_uri: "https://vault.world.dev.cardano.org/v1/sops/keys/ops"
   - path_regex: faucet/preprod*

--- a/nix/cloud/kv/vault/db-sync/private.enc.yaml
+++ b/nix/cloud/kv/vault/db-sync/private.enc.yaml
@@ -1,0 +1,18 @@
+pgUser: ENC[AES256_GCM,data:qx9chypGb9iudLUWG0U=,iv:kaSTFz2/Ik/hBQgaqtdXQ+VRp/Hm4YlRS1CzFnHYx0k=,tag:kU8sWw6sDfONxc0D8XtxwQ==,type:str]
+pgPass: ENC[AES256_GCM,data:KZkFX3EDYX+C/Tgem0cNXZaBIVd/wZbKnPf4r6HnZ9z/nX7VEWa/fc1cxAEZ/B2FAa6VzauAnbCiBakNlLUufQ==,iv:M4yLOjeVWlYZvcD1OSmxaObCDe1/vy8m/Soid8HfXnU=,tag:GDa+KUzU3DGnVoZdyT6o1g==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault:
+        - vault_address: https://vault.world.dev.cardano.org
+          engine_path: sops
+          key_name: ops
+          created_at: "2022-08-15T22:38:10Z"
+          enc: vault:v1:+GlMbGfXK+hYtkd0fnV8PApO3pm885XxWtMeFfBYSYS1uCtEF2nI7RSi40TjbMKwAikvyrqvJOzqHV68
+    age: []
+    lastmodified: "2023-02-13T20:26:51Z"
+    mac: ENC[AES256_GCM,data:DTzsqGL7aWWPmra+zGSXt0Knr7sVmiDk74bbYgD53kR/efHoKxD8+CJJEhNKduchs8CGSWA8+B0CX7sUT8e3giMzsKX7vhGaYhvO/mSIuIkP/eZXxKEdcc/h/EL8YqPum0K3la3zycxzy38tX1ifjqnSyz2yqLMwo4HdAE4IMRA=,iv:5w4cXMTZW2iOgl7RyD9T0iHAy8iu28PXQLCHIhR75Ew=,tag:rzi/tZIb1jsue07cgFtFMg==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.3


### PR DESCRIPTION
* Drop the requirement for 0:0 user in images by making the following changes:

* Align with nobody:nogroup between images and nomad
* Adjust entrypoints and scripts for the associated perms
* During deployment, chmod -R nobody:nogroup pre-existing state directories on the host for each updated image (node, db-sync, faucet, ogmios, submit-api, wallet) to set state to the new image user and group
* Return to bitte master now that the user id error is resolved