### PR TITLE
add entry-point for mithril-signer

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2543,6 +2543,30 @@
         "type": "github"
       }
     },
+    "crane_2": {
+      "inputs": {
+        "flake-compat": "flake-compat_36",
+        "flake-utils": "flake-utils_74",
+        "nixpkgs": [
+          "mithril",
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay_4"
+      },
+      "locked": {
+        "lastModified": 1688772518,
+        "narHash": "sha256-ol7gZxwvgLnxNSZwFTDJJ49xVY5teaSvF7lzlo3YQfM=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "8b08e96c9af8c6e3a2b69af5a7fa168750fcf88e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "customConfig": {
       "locked": {
         "narHash": "sha256-Zd5w1I1Dwt783Q4WuBuCpedcwG1DrIgQGqabyF87prM=",
@@ -4809,6 +4833,22 @@
     "flake-compat_36": {
       "flake": false,
       "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_37": {
+      "flake": false,
+      "locked": {
         "lastModified": 1650374568,
         "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
         "owner": "edolstra",
@@ -4822,7 +4862,7 @@
         "type": "github"
       }
     },
-    "flake-compat_37": {
+    "flake-compat_38": {
       "flake": false,
       "locked": {
         "lastModified": 1650374568,
@@ -4957,6 +4997,24 @@
     "flake-parts_2": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1678379998,
+        "narHash": "sha256-TZdfNqftHhDuIFwBcN9MUThx5sQXCTeZk9je5byPKRw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c13d60b89adea3dc20704c045ec4d50dd964d447",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
         "lastModified": 1665512413,
@@ -6043,12 +6101,15 @@
       }
     },
     "flake-utils_74": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1687709756,
+        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
         "type": "github"
       },
       "original": {
@@ -6074,6 +6135,21 @@
     },
     "flake-utils_76": {
       "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_77": {
+      "locked": {
         "lastModified": 1653893745,
         "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
         "owner": "numtide",
@@ -6087,7 +6163,7 @@
         "type": "github"
       }
     },
-    "flake-utils_77": {
+    "flake-utils_78": {
       "locked": {
         "lastModified": 1659877975,
         "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
@@ -6641,7 +6717,7 @@
     },
     "gomod2nix_9": {
       "inputs": {
-        "nixpkgs": "nixpkgs_100",
+        "nixpkgs": "nixpkgs_101",
         "utils": "utils_30"
       },
       "locked": {
@@ -9270,6 +9346,27 @@
         "type": "github"
       }
     },
+    "mithril": {
+      "inputs": {
+        "crane": "crane_2",
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": "nixpkgs_98",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1691499862,
+        "narHash": "sha256-Qg4j8W76XI/lYmZeRVulgW5T4L8zx9yvETX5sB5M5NM=",
+        "owner": "input-output-hk",
+        "repo": "mithril",
+        "rev": "6a3b402a878b27caec5db8a1b3cdf322ad93ff7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "mithril",
+        "type": "github"
+      }
+    },
     "n2c": {
       "inputs": {
         "flake-utils": "flake-utils_2",
@@ -9623,7 +9720,7 @@
     },
     "napalm": {
       "inputs": {
-        "flake-utils": "flake-utils_74",
+        "flake-utils": "flake-utils_75",
         "nixpkgs": [
           "openziti",
           "nixpkgs"
@@ -10052,7 +10149,7 @@
     },
     "nix-nomad_9": {
       "inputs": {
-        "flake-compat": "flake-compat_37",
+        "flake-compat": "flake-compat_38",
         "flake-utils": [
           "tullia",
           "nix2container",
@@ -10282,8 +10379,8 @@
     },
     "nix2container_11": {
       "inputs": {
-        "flake-utils": "flake-utils_76",
-        "nixpkgs": "nixpkgs_101"
+        "flake-utils": "flake-utils_77",
+        "nixpkgs": "nixpkgs_102"
       },
       "locked": {
         "lastModified": 1658567952,
@@ -12254,6 +12351,24 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
+        "lastModified": 1678375444,
+        "narHash": "sha256-XIgHfGvjFvZQ8hrkfocanCDxMefc/77rXeHvYdzBMc8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "130fa0baaa2b93ec45523fdcde942f6844ee9f6e",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_2": {
+      "locked": {
+        "dir": "lib",
         "lastModified": 1665349835,
         "narHash": "sha256-UK4urM3iN80UXQ7EaOappDzcisYIuEURFRoGQ/yPkug=",
         "owner": "NixOS",
@@ -12759,6 +12874,22 @@
     },
     "nixpkgs_100": {
       "locked": {
+        "lastModified": 1665087388,
+        "narHash": "sha256-FZFPuW9NWHJteATOf79rZfwfRn5fE0wi9kRzvGfDHPA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "95fda953f6db2e9496d2682c4fc7b82f959878f7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_101": {
+      "locked": {
         "lastModified": 1653581809,
         "narHash": "sha256-Uvka0V5MTGbeOfWte25+tfRL3moECDh1VwokWSZUdoY=",
         "owner": "NixOS",
@@ -12773,7 +12904,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_101": {
+    "nixpkgs_102": {
       "locked": {
         "lastModified": 1654807842,
         "narHash": "sha256-ADymZpr6LuTEBXcy6RtFHcUZdjKTBRTMYwu19WOx17E=",
@@ -12788,7 +12919,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_102": {
+    "nixpkgs_103": {
       "locked": {
         "lastModified": 1653920503,
         "narHash": "sha256-BBeCZwZImtjP3oYy4WogkQYy5OxNyfNciVSc1AfZgLQ=",
@@ -12804,7 +12935,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_103": {
+    "nixpkgs_104": {
       "locked": {
         "lastModified": 1665087388,
         "narHash": "sha256-FZFPuW9NWHJteATOf79rZfwfRn5fE0wi9kRzvGfDHPA=",
@@ -14291,6 +14422,22 @@
     },
     "nixpkgs_98": {
       "locked": {
+        "lastModified": 1687886075,
+        "narHash": "sha256-PeayJDDDy+uw1Ats4moZnRdL1OFuZm1Tj+KiHlD67+o=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "a565059a348422af5af9026b5174dc5c0dcefdae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_99": {
+      "locked": {
         "lastModified": 1676300157,
         "narHash": "sha256-1HjRzfp6LOLfcj/HJHdVKWAkX9QRAouoh6AjzJiIerU=",
         "owner": "NixOS",
@@ -14301,22 +14448,6 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_99": {
-      "locked": {
-        "lastModified": 1665087388,
-        "narHash": "sha256-FZFPuW9NWHJteATOf79rZfwfRn5fE0wi9kRzvGfDHPA=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "95fda953f6db2e9496d2682c4fc7b82f959878f7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -14789,10 +14920,10 @@
     },
     "openziti": {
       "inputs": {
-        "flake-compat": "flake-compat_36",
-        "flake-parts": "flake-parts_2",
+        "flake-compat": "flake-compat_37",
+        "flake-parts": "flake-parts_3",
         "napalm": "napalm",
-        "nixpkgs": "nixpkgs_98",
+        "nixpkgs": "nixpkgs_99",
         "nixpkgs-darwin": "nixpkgs-darwin",
         "zitiConsole": "zitiConsole"
       },
@@ -15190,6 +15321,7 @@
         "hackage": "hackage_14",
         "haskell-nix": "haskell-nix_3",
         "iohk-nix": "iohk-nix",
+        "mithril": "mithril",
         "n2c": [
           "std",
           "n2c"
@@ -15338,6 +15470,33 @@
         "owner": "oxalica",
         "repo": "rust-overlay",
         "rev": "14c48021a9a5fe6ea8ae6b21c15caa106afa9d19",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_4": {
+      "inputs": {
+        "flake-utils": [
+          "mithril",
+          "crane",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "mithril",
+          "crane",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1688351637,
+        "narHash": "sha256-CLTufJ29VxNOIZ8UTg0lepsn3X03AmopmaLTTeHDCL4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "f9b92316727af9e6c7fee4a761242f7f46880329",
         "type": "github"
       },
       "original": {
@@ -15911,7 +16070,7 @@
         "blank": "blank_11",
         "devshell": "devshell_22",
         "dmerge": "dmerge_12",
-        "flake-utils": "flake-utils_75",
+        "flake-utils": "flake-utils_76",
         "incl": "incl_6",
         "makes": [
           "std",
@@ -15923,7 +16082,7 @@
         ],
         "n2c": "n2c_13",
         "nixago": "nixago_12",
-        "nixpkgs": "nixpkgs_99",
+        "nixpkgs": "nixpkgs_100",
         "nosys": "nosys_6",
         "yants": "yants_15"
       },
@@ -15951,7 +16110,7 @@
         "blank": "blank_12",
         "devshell": "devshell_23",
         "dmerge": "dmerge_13",
-        "flake-utils": "flake-utils_77",
+        "flake-utils": "flake-utils_78",
         "incl": "incl_7",
         "makes": [
           "tullia",
@@ -15965,7 +16124,7 @@
         ],
         "n2c": "n2c_14",
         "nixago": "nixago_13",
-        "nixpkgs": "nixpkgs_103",
+        "nixpkgs": "nixpkgs_104",
         "nosys": "nosys_7",
         "yants": "yants_16"
       },
@@ -16417,6 +16576,21 @@
         "type": "github"
       }
     },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "tailwind-haskell": {
       "inputs": {
         "flake-compat": "flake-compat_6",
@@ -16575,6 +16749,27 @@
         "owner": "hasura",
         "repo": "text",
         "rev": "ba0fd2bf256c996a6c85dbdc8590a6fcde41b8f8",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "mithril",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1678901796,
+        "narHash": "sha256-9myDjq948gHbiv16HnFQZaswQEpNodE/CuGCfDNnv/g=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "0f560a84215e79facd2833b20bfdc2033266f126",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
         "type": "github"
       }
     },
@@ -16758,7 +16953,7 @@
       "inputs": {
         "nix-nomad": "nix-nomad_9",
         "nix2container": "nix2container_11",
-        "nixpkgs": "nixpkgs_102",
+        "nixpkgs": "nixpkgs_103",
         "std": "std_13"
       },
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,7 @@
     cardano-db-sync.url = "github:input-output-hk/cardano-db-sync/13.0.4";
     cardano-node.url = "github:input-output-hk/cardano-node/8.1.2";
     cardano-wallet.url = "github:input-output-hk/cardano-wallet/v2022-07-01";
+    mithril.url = "github:input-output-hk/mithril";
     offchain-metadata-tools = {
       url = "github:input-output-hk/offchain-metadata-tools/pg-cli-mods";
       flake = false;

--- a/nix/cardano/devshellProfiles.nix
+++ b/nix/cardano/devshellProfiles.nix
@@ -51,7 +51,7 @@ rec {
   dev = _: {
     imports = [
       minimal
-      packages.project.devshell
+      (haskell-nix.haskellLib.devshellFor packages.project)
     ];
 
     commands = [

--- a/nix/cardano/packages/default.nix
+++ b/nix/cardano/packages/default.nix
@@ -12,6 +12,7 @@ let
     cardano-node
     cardano-wallet
     cardano-db-sync
+    mithril
     ogmios
     cardano-graphql
     offchain-metadata-tools
@@ -27,10 +28,11 @@ in lib.makeOverridable ({ evalSystem ? nixpkgs.system }: let
     (import inputs.nixpkgs-haskell {
       inherit (nixpkgs) system;
       inherit (inputs.haskell-nix) config;
-      overlays = with iohk-nix.overlays; [
+      overlays = [
+        iohk-nix.overlays.crypto
         inputs.haskell-nix.overlay
-        haskell-nix-extra
-        crypto
+        iohk-nix.overlays.haskell-nix-crypto
+        iohk-nix.overlays.haskell-nix-extra
         (final: prev: {
           haskellBuildUtils = prev.haskellBuildUtils.override {
             inherit compiler-nix-name index-state evalSystem;
@@ -81,6 +83,7 @@ in
   inherit (project.exes) cardano-new-faucet;
   inherit (cardano-wallet.packages) cardano-wallet;
   inherit (cardano-wallet.packages) cardano-address;
+  inherit (mithril.packages) mithril-signer mithril-client;
   inherit (cardano-db-sync.packages) cardano-db-sync cardano-db-tool;
   inherit (ogmiosProject.hsPkgs.ogmios.components.exes) ogmios;
   inherit nix-inclusive; # TODO REMOVE


### PR DESCRIPTION
Still need integration in `nix/cardano/nomadCharts` and `nix/cloud/namespaces`. Also for a reverse-proxy (traefik ?), to serve as mithril-relay.